### PR TITLE
Yuzu fix handheld mode option and add ryujinx controller type choice

### DIFF
--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -9651,12 +9651,30 @@
       <choice name="OPENAL" value="OpenAl"/>
       <choice name="SOUNDIO" value="SoundIo"/>
     </feature>
-    <feature submenu="CONTROLS" name="CONTROLLER TYPE" group="ADVANCED SETTINGS" value="ryujinx_padtype" description="Sets the player controller type">
+    <feature submenu="CONTROLS" name="CONTROLLER TYPE PLAYER 1" group="ADVANCED SETTINGS" value="ryujinx_padtype1" description="Sets the player controller type">
       <choice name="PRO CONTROLLER" value="ProController"/>
       <choice name="DUAL JOYCON" value="JoyconPair"/>
       <choice name="LEFT JOYCON" value="JoyconLeft"/>
       <choice name="RIGHT JOYCON" value="JoyconRight"/>
       <choice name="HANDHELD" value="Handheld"/>
+    </feature>
+    <feature submenu="CONTROLS" name="CONTROLLER TYPE PLAYER 2" group="ADVANCED SETTINGS" value="ryujinx_padtype2" description="Sets the player controller type">
+      <choice name="PRO CONTROLLER" value="ProController"/>
+      <choice name="DUAL JOYCON" value="JoyconPair"/>
+      <choice name="LEFT JOYCON" value="JoyconLeft"/>
+      <choice name="RIGHT JOYCON" value="JoyconRight"/>
+    </feature>
+    <feature submenu="CONTROLS" name="CONTROLLER TYPE PLAYER 3" group="ADVANCED SETTINGS" value="ryujinx_padtype3" description="Sets the player controller type">
+      <choice name="PRO CONTROLLER" value="ProController"/>
+      <choice name="DUAL JOYCON" value="JoyconPair"/>
+      <choice name="LEFT JOYCON" value="JoyconLeft"/>
+      <choice name="RIGHT JOYCON" value="JoyconRight"/>
+    </feature>
+    <feature submenu="CONTROLS" name="CONTROLLER TYPE PLAYER 4" group="ADVANCED SETTINGS" value="ryujinx_padtype4" description="Sets the player controller type">
+      <choice name="PRO CONTROLLER" value="ProController"/>
+      <choice name="DUAL JOYCON" value="JoyconPair"/>
+      <choice name="LEFT JOYCON" value="JoyconLeft"/>
+      <choice name="RIGHT JOYCON" value="JoyconRight"/>
     </feature>
     <feature submenu="CONTROLS" name="INVERT A/B AND X/Y" group="ADVANCED SETTINGS" value="ryujinx_gamepadbuttons" description="Invert A/B and X/Y buttons on Xbox controllers.">
       <choice name="NO" value="0"/>

--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -9651,6 +9651,13 @@
       <choice name="OPENAL" value="OpenAl"/>
       <choice name="SOUNDIO" value="SoundIo"/>
     </feature>
+    <feature submenu="CONTROLS" name="CONTROLLER TYPE" group="ADVANCED SETTINGS" value="ryujinx_padtype" description="Sets the player controller type">
+      <choice name="PRO CONTROLLER" value="ProController"/>
+      <choice name="DUAL JOYCON" value="JoyconPair"/>
+      <choice name="LEFT JOYCON" value="JoyconLeft"/>
+      <choice name="RIGHT JOYCON" value="JoyconRight"/>
+      <choice name="HANDHELD" value="Handheld"/>
+    </feature>
     <feature submenu="CONTROLS" name="INVERT A/B AND X/Y" group="ADVANCED SETTINGS" value="ryujinx_gamepadbuttons" description="Invert A/B and X/Y buttons on Xbox controllers.">
       <choice name="NO" value="0"/>
       <choice name="YES" value="1"/>

--- a/emulatorLauncher/Generators/Ryujinx.Controllers.cs
+++ b/emulatorLauncher/Generators/Ryujinx.Controllers.cs
@@ -71,10 +71,10 @@ namespace emulatorLauncher
 
             string playerType = "ProController";
 
-            if (SystemConfig.isOptSet("ryujinx_padtype") && !string.IsNullOrEmpty(SystemConfig["ryujinx_padtype"]))
-                playerType = SystemConfig["ryujinx_padtype"];
+            if (SystemConfig.isOptSet("ryujinx_padtype1") && !string.IsNullOrEmpty(SystemConfig["ryujinx_padtype1"]))
+                playerType = SystemConfig["ryujinx_padtype1"];
 
-            bool handheld = SystemConfig["ryujinx_padtype"] == "Handheld";
+            bool handheld = playerType == "Handheld";
 
             //Define action for keyboard mapping
             Action<DynamicJson, string, InputKey> WriteKeyboardMapping = (v, w, k) =>
@@ -180,11 +180,12 @@ namespace emulatorLauncher
                 return;
 
             string playerType = "ProController";
+            string padType = "ryujinx_padtype" + playerIndex.ToString();
 
-            if (SystemConfig.isOptSet("ryujinx_padtype") && !string.IsNullOrEmpty(SystemConfig["ryujinx_padtype"]))
-                playerType = SystemConfig["ryujinx_padtype"];
+            if (SystemConfig.isOptSet(padType) && !string.IsNullOrEmpty(SystemConfig[padType]))
+                playerType = SystemConfig[padType];
 
-            bool handheld = SystemConfig["ryujinx_padtype"] == "Handheld";
+            bool handheld = playerType == "Handheld";
 
             //Define tech (SDL or XInput)
             string tech = c.IsXInputDevice ? "XInput" : "SDL";

--- a/emulatorLauncher/Generators/Ryujinx.Controllers.cs
+++ b/emulatorLauncher/Generators/Ryujinx.Controllers.cs
@@ -69,6 +69,13 @@ namespace emulatorLauncher
             if (keyboard == null)
                 return;
 
+            string playerType = "ProController";
+
+            if (SystemConfig.isOptSet("ryujinx_padtype") && !string.IsNullOrEmpty(SystemConfig["ryujinx_padtype"]))
+                playerType = SystemConfig["ryujinx_padtype"];
+
+            bool handheld = SystemConfig["ryujinx_padtype"] == "Handheld";
+
             //Define action for keyboard mapping
             Action<DynamicJson, string, InputKey> WriteKeyboardMapping = (v, w, k) =>
             {
@@ -100,10 +107,22 @@ namespace emulatorLauncher
 
             var left_joycon = new DynamicJson();
             WriteKeyboardMapping(left_joycon, "button_minus", InputKey.select);
-            WriteKeyboardMapping(left_joycon, "button_l", InputKey.pageup);
-            WriteKeyboardMapping(left_joycon, "button_zl", InputKey.l2);
-            left_joycon["button_sl"] = "Unbound";
-            left_joycon["button_sr"] = "Unbound";
+
+            if (playerType == "JoyconLeft")
+            {
+                left_joycon["button_l"] = "Unbound";
+                left_joycon["button_zl"] = "Unbound";
+                WriteKeyboardMapping(left_joycon, "button_sl", InputKey.pageup);
+                WriteKeyboardMapping(left_joycon, "button_sr", InputKey.pagedown);
+            }
+            else
+            {
+                WriteKeyboardMapping(left_joycon, "button_l", InputKey.pageup);
+                WriteKeyboardMapping(left_joycon, "button_zl", InputKey.l2);
+                left_joycon["button_sl"] = "Unbound";
+                left_joycon["button_sr"] = "Unbound";
+            }
+
             WriteKeyboardMapping(left_joycon, "dpad_up", InputKey.up);
             WriteKeyboardMapping(left_joycon, "dpad_down", InputKey.down);
             WriteKeyboardMapping(left_joycon, "dpad_left", InputKey.left);
@@ -112,10 +131,22 @@ namespace emulatorLauncher
 
             var right_joycon = new DynamicJson();
             WriteKeyboardMapping(right_joycon, "button_plus", InputKey.start);
-            WriteKeyboardMapping(right_joycon, "button_r", InputKey.pagedown);
-            WriteKeyboardMapping(right_joycon, "button_zr", InputKey.r2);
-            right_joycon["button_sl"] = "Unbound";
-            right_joycon["button_sr"] = "Unbound";
+
+            if (playerType == "JoyconRight")
+            {
+                right_joycon["button_r"] = "Unbound";
+                right_joycon["button_zr"] = "Unbound";
+                WriteKeyboardMapping(right_joycon, "button_sl", InputKey.pageup);
+                WriteKeyboardMapping(right_joycon, "button_sr", InputKey.pagedown);
+            }
+            else
+            {
+                WriteKeyboardMapping(right_joycon, "button_r", InputKey.pagedown);
+                WriteKeyboardMapping(right_joycon, "button_zr", InputKey.r2);
+                right_joycon["button_sl"] = "Unbound";
+                right_joycon["button_sr"] = "Unbound";
+            }
+
             WriteKeyboardMapping(right_joycon, "button_x", InputKey.x);
             WriteKeyboardMapping(right_joycon, "button_b", InputKey.b);
             WriteKeyboardMapping(right_joycon, "button_y", InputKey.y);
@@ -125,8 +156,8 @@ namespace emulatorLauncher
             input_config["version"] = "1";
             input_config["backend"] = "WindowKeyboard";
             input_config["id"] = "\"" + "0" + "\"";
-            input_config["controller_type"] = "ProController";
-            input_config["player_index"] = "Player1";
+            input_config["controller_type"] = playerType;
+            input_config["player_index"] = handheld ? "Handheld" : "Player1";
 
             input_configs.Add(input_config);
             json.SetObject("input_config", input_configs);
@@ -147,6 +178,13 @@ namespace emulatorLauncher
             InputConfig joy = c.Config;
             if (joy == null)
                 return;
+
+            string playerType = "ProController";
+
+            if (SystemConfig.isOptSet("ryujinx_padtype") && !string.IsNullOrEmpty(SystemConfig["ryujinx_padtype"]))
+                playerType = SystemConfig["ryujinx_padtype"];
+
+            bool handheld = SystemConfig["ryujinx_padtype"] == "Handheld";
 
             //Define tech (SDL or XInput)
             string tech = c.IsXInputDevice ? "XInput" : "SDL";
@@ -208,10 +246,22 @@ namespace emulatorLauncher
             //left joycon buttons mapping
             var left_joycon = new DynamicJson();
             left_joycon["button_minus"] = GetInputKeyName(c, InputKey.select, tech);
-            left_joycon["button_l"] = GetInputKeyName(c, InputKey.pageup, tech);
-            left_joycon["button_zl"] = GetInputKeyName(c, InputKey.l2, tech);
-            left_joycon["button_sl"] = "Unbound";
-            left_joycon["button_sr"] = "Unbound";
+
+            if (playerType == "JoyconLeft")
+            {
+                left_joycon["button_l"] = "Unbound";
+                left_joycon["button_zl"] = "Unbound";
+                left_joycon["button_sl"] = GetInputKeyName(c, InputKey.pageup, tech);
+                left_joycon["button_sr"] = GetInputKeyName(c, InputKey.pagedown, tech);
+            }
+            else
+            {
+                left_joycon["button_l"] = GetInputKeyName(c, InputKey.pageup, tech);
+                left_joycon["button_zl"] = GetInputKeyName(c, InputKey.l2, tech);
+                left_joycon["button_sl"] = "Unbound";
+                left_joycon["button_sr"] = "Unbound";
+            }
+
             left_joycon["dpad_up"] = GetInputKeyName(c, InputKey.up, tech);
             left_joycon["dpad_down"] = GetInputKeyName(c, InputKey.down, tech);
             left_joycon["dpad_left"] = GetInputKeyName(c, InputKey.left, tech);
@@ -221,10 +271,21 @@ namespace emulatorLauncher
             //right joycon buttons mapping
             var right_joycon = new DynamicJson();
             right_joycon["button_plus"] = GetInputKeyName(c, InputKey.start, tech);
-            right_joycon["button_r"] = GetInputKeyName(c, InputKey.pagedown, tech);
-            right_joycon["button_zr"] = GetInputKeyName(c, InputKey.r2, tech);
-            right_joycon["button_sl"] = "Unbound";
-            right_joycon["button_sr"] = "Unbound";
+
+            if (playerType == "JoyconRight")
+            {
+                right_joycon["button_r"] = "Unbound";
+                right_joycon["button_zr"] = "Unbound";
+                right_joycon["button_sl"] = GetInputKeyName(c, InputKey.pageup, tech);
+                right_joycon["button_sr"] = GetInputKeyName(c, InputKey.pagedown, tech);
+            }
+            else
+            {
+                right_joycon["button_r"] = GetInputKeyName(c, InputKey.pagedown, tech);
+                right_joycon["button_zr"] = GetInputKeyName(c, InputKey.r2, tech);
+                right_joycon["button_sl"] = "Unbound";
+                right_joycon["button_sr"] = "Unbound";
+            }
 
             // Invert button positions for XBOX controllers
             if (c.IsXInputDevice && Program.SystemConfig.isOptSet("ryujinx_gamepadbuttons") && Program.SystemConfig.getOptBoolean("ryujinx_gamepadbuttons"))
@@ -252,8 +313,8 @@ namespace emulatorLauncher
             input_config["version"] = "1";
             input_config["backend"] = "GamepadSDL2";
             input_config["id"] = index + "-" + newguid.ToString();
-            input_config["controller_type"] = "ProController";
-            input_config["player_index"] = "Player" + playerIndex;
+            input_config["controller_type"] = playerType;
+            input_config["player_index"] = handheld ? "Handheld" : "Player" + playerIndex;
 
             //add section to file
             input_configs.Add(input_config);

--- a/emulatorLauncher/Generators/Ryujinx.Generator.cs
+++ b/emulatorLauncher/Generators/Ryujinx.Generator.cs
@@ -85,7 +85,7 @@ namespace emulatorLauncher
             json["show_console"] = "false";
 
             //Input
-            BindFeature(json, "docked_mode", "ryujinx_undock", "true");
+            BindBoolFeature(json, "docked_mode", "ryujinx_undock", "false", "true");
             json["hide_cursor_on_idle"] = "true";
 
             // Discord

--- a/emulatorLauncher/Generators/Yuzu.Controllers.cs
+++ b/emulatorLauncher/Generators/Yuzu.Controllers.cs
@@ -106,12 +106,14 @@ namespace emulatorLauncher
                 string id = SystemConfig[playerType];
                 if (!string.IsNullOrEmpty(id))
                     playerTypeId = id.ToInteger();
-            }            
+            }
+
+            bool handheld = playerTypeId == 4;
 
             ini.WriteValue("Controls", player + "type" + "\\default",  playerTypeId == 0 ? "true" : "false");
             ini.WriteValue("Controls", player + "type", playerTypeId.ToString());
             ini.WriteValue("Controls", player + "connected" + "\\default", "false");
-            ini.WriteValue("Controls", player + "connected", "true");
+            ini.WriteValue("Controls", player + "connected", handheld ? "false" : "true");
 
             //Vibration settings
             ini.WriteValue("Controls", player + "vibration_enabled" + "\\default", "true");

--- a/emulatorLauncher/Generators/Yuzu.Controllers.cs
+++ b/emulatorLauncher/Generators/Yuzu.Controllers.cs
@@ -297,12 +297,31 @@ namespace emulatorLauncher
             if (keyboard == null)
                 return;
 
+            // player_0_type=1 Pro controller
+            // player_0_type=1 Dual joycon
+            // player_0_type=2 Left joycon
+            // player_0_type=3 Right joycon
+            // player_0_type=4 Handheld
+            // player_0_type=5 Gamecube controller
+
+            int playerTypeId = 0;
+
             string player = "player_" + (controller.PlayerIndex - 1) + "_";
 
-            ini.WriteValue("Controls", player + "type" + "\\default", "true");
-            ini.WriteValue("Controls", player + "type", "0");
-            ini.WriteValue("Controls", player + "connected" + "\\default", "true");
-            ini.WriteValue("Controls", player + "connected", "true");
+            string playerType = player + "type";
+            if (Program.Features.IsSupported(playerType) && Program.SystemConfig.isOptSet(playerType))
+            {
+                string id = Program.SystemConfig[playerType];
+                if (!string.IsNullOrEmpty(id))
+                    playerTypeId = id.ToInteger();
+            }
+
+            bool handheld = playerTypeId == 4;
+
+            ini.WriteValue("Controls", player + "type" + "\\default", playerTypeId == 0 ? "true" : "false");
+            ini.WriteValue("Controls", player + "type", playerTypeId.ToString());
+            ini.WriteValue("Controls", player + "connected" + "\\default", "false");
+            ini.WriteValue("Controls", player + "connected", handheld ? "false" : "true");
             ini.WriteValue("Controls", player + "vibration_enabled" + "\\default", "true");
             ini.WriteValue("Controls", player + "vibration_enabled", "true");
             ini.WriteValue("Controls", player + "left_vibration_device" + "\\default", "true");


### PR DESCRIPTION
When using "handheld" controller type, player_0_connected must be equal to "false" instead of true.

In ryujinx option to select controller type was not yet implemented.

fixes https://github.com/RetroBat-Official/emulatorlauncher/issues/10