### PR TITLE
PCSX2 guns - add option for timecrisis

### DIFF
--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -11086,7 +11086,7 @@
         <choice name="IN USB 2 PORT" value="USB2"/>
       </feature>
       <feature submenu="GUNS" name="GUNCON BUTTON MAPPING" group="ADVANCED SETTINGS" value="pcsx2_gunmapping" description="Define how to map the guncon2 buttons.">
-        <choice name="KEYBOARD (MOUSE MIDDLE as START)" value="keyboard_middle"/>
+        <choice name="KEYBOARD AND MOUSE (MOUSE MIDDLE as START, MOUSE LEFT as A)" value="keyboard_middle"/>
         <choice name="KEYBOARD (RETURN as START)" value="keyboard_return"/>
         <choice name="KEYBOARD (VOL+ and VOL- as A/B)" value="keyboard_volume"/>
         <choice name="GAMEPAD" value="controller"/>

--- a/emulatorLauncher/Generators/Pcsx2.Controllers.cs
+++ b/emulatorLauncher/Generators/Pcsx2.Controllers.cs
@@ -10,6 +10,7 @@ using System.Management;
 using EmulatorLauncher.Common.FileFormats;
 using EmulatorLauncher.Common.Joysticks;
 using EmulatorLauncher.Common.EmulationStation;
+using System.Windows.Input;
 
 namespace EmulatorLauncher
 {
@@ -577,7 +578,11 @@ namespace EmulatorLauncher
             // Configure gun for player 1 if option is set in es_features
             pcsx2ini.WriteValue(usbSection, "Type", "guncon2");
             pcsx2ini.WriteValue(usbSection, "guncon2_Trigger", guninvert ? "Pointer-0/RightButton" : "Pointer-0/LeftButton");
-            pcsx2ini.WriteValue(usbSection, "guncon2_ShootOffscreen", guninvert ? "Pointer-0/LeftButton" : "Pointer-0/RightButton");
+            
+            if (SystemConfig["pcsx2_gunmapping"] == "keyboard_middle")
+                pcsx2ini.WriteValue(usbSection, "guncon2_ShootOffscreen", "Keyboard/1");
+            else
+                pcsx2ini.WriteValue(usbSection, "guncon2_ShootOffscreen", guninvert ? "Pointer-0/LeftButton" : "Pointer-0/RightButton");
             
             if (SystemConfig.isOptSet("gun_calibrate") && SystemConfig["gun_calibrate"] == "trigger")
                 pcsx2ini.WriteValue(usbSection, "guncon2_Recalibrate", guninvert ? "Pointer-0/RightButton" : "Pointer-0/LeftButton");
@@ -606,6 +611,7 @@ namespace EmulatorLauncher
                 pcsx2ini.WriteValue(usbSection, "guncon2_Down", "Keyboard/Down");
                 pcsx2ini.WriteValue(usbSection, "guncon2_Left", "Keyboard/Left");
                 pcsx2ini.WriteValue(usbSection, "guncon2_Right", "Keyboard/Right");
+                
                 if (SystemConfig.isOptSet("pcsx2_gunmapping") && SystemConfig["pcsx2_gunmapping"] == "keyboard_volume")
                 {
                     pcsx2ini.WriteValue(usbSection, "guncon2_A", "Keyboard/VolumeUp");
@@ -619,8 +625,12 @@ namespace EmulatorLauncher
 
                 pcsx2ini.WriteValue(usbSection, "guncon2_C", "Keyboard/3");
                 pcsx2ini.WriteValue(usbSection, "guncon2_Select", "Keyboard/Backspace");
+
                 if (SystemConfig.isOptSet("pcsx2_gunmapping") && SystemConfig["pcsx2_gunmapping"] == "keyboard_middle")
+                {
+                    pcsx2ini.WriteValue(usbSection, "guncon2_A", guninvert ? "Pointer-0/LeftButton" : "Pointer-0/RightButton");
                     pcsx2ini.WriteValue(usbSection, "guncon2_Start", "Pointer-0/MiddleButton");
+                }
                 else
                     pcsx2ini.WriteValue(usbSection, "guncon2_Start", "Keyboard/Return");
             }


### PR DESCRIPTION
Time crisis uses button A to hide / reload, option to map it with right mouse button instead of offscreen reload