### PR TITLE
add vulkan driver compatibility (driver & shaders)

### DIFF
--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -12537,13 +12537,17 @@
   <!-- SNES9X -->
   <emulator name="snes9x" features="padtokeyboard">
     <feature name="SHADER SET" group="GENERAL SETTINGS" value="snes9x_shader">
-      <choice name="CURVATURE" value="crt\crt-geom.glslp"/>
-      <choice name="SCANLINES" value="crt\GritsScanlines.glslp"/>
-      <choice name="ZFAST-COMPOSITE" value="crt\zfast-composite.glslp"/>
-      <choice name="NTSC-256PX-SVIDEO" value="ntsc\ntsc-256px-svideo-gauss-scanline.glslp"/>
+      <choice name="CURVATURE" value="crt\crt-geom"/>
+      <choice name="SCANLINES" value="crt\GritsScanlines"/>
+      <choice name="OSSC SLOT" value="scanlines\ossc_slot.slangp"/>
+      <choice name="CRT MATTIAS" value="crt\crt-mattias"/>
+      <choice name="CRT NEW PIXIE" value="crt\newpixie-crt.slangp"/>
+      <choice name="DOT" value="handheld\dot"/>
+      <choice name="ZFAST-LCD" value="handheld\zfast-lcd"/>
       <choice name="SUPER EAGLE" value="eagle\super-eagle.glslp"/>
-      <choice name="SABR" value="sabr\sabr.glslp"/>
-      <choice name="NEDI" value="nedi\nedi.glslp"/>
+      <choice name="SABR" value="sabr\sabr"/>
+      <choice name="SCALE HQ 2X" value="scalehq\2xScaleHQ.glslp"/>
+      <choice name="SCALE HQ 4X" value="scalehq\4xScaleHQ.glslp"/>
     </feature>
     <sharedFeature group="GENERAL SETTINGS" value="bezel"/>
     <feature name="GAME ASPECT RATIO" group="GENERAL SETTINGS" value="snes9x_ratio">
@@ -12571,6 +12575,10 @@
       <choice name="COMPOSITE" value="6"/>
       <choice name="S-VIDEO" value="7"/>
       <choice name="RGB" value="8"/>
+    </feature>
+    <feature submenu="DRIVER" name="VIDEO" group="ADVANCED SETTINGS" value="snes9x_renderer">
+      <choice name="OPENGL" value="opengl"/>
+      <choice name="VULKAN" value="vulkan"/>
     </feature>
   </emulator>
   <!-- SOLARUS -->

--- a/emulatorLauncher/Generators/Snes9x.Generator.cs
+++ b/emulatorLauncher/Generators/Snes9x.Generator.cs
@@ -28,6 +28,7 @@ namespace EmulatorLauncher
 				return null;
 
 			//Applying bezels
+
 			if (!ReshadeManager.Setup(ReshadeBezelType.opengl, ReshadePlatform.x64, system, rom, path, resolution))
 				_bezelFileInfo = BezelFiles.GetBezelFiles(system, rom, resolution);
 
@@ -70,12 +71,15 @@ namespace EmulatorLauncher
 			if (!File.Exists(conf))
 				return;
 
-            bool fullscreen = !IsEmulationStationWindowed() || SystemConfig.getOptBoolean("forcefullscreen");
+			bool fullscreen = !IsEmulationStationWindowed() || SystemConfig.getOptBoolean("forcefullscreen");
 
             using (var ini = IniFile.FromFile(conf, IniOptions.KeepEmptyLines))
 			{
 
-				// Inject path loop
+				string shaderPath;
+
+				// Inject path
+
 				Dictionary<string, string> userPath = new Dictionary<string, string>
 				{
 					{ "Dir:Roms", Path.Combine(AppConfig.GetFullPath("roms"), system) },
@@ -97,10 +101,11 @@ namespace EmulatorLauncher
 				}
 
 				// General settings
+
 				ini.WriteValue(@"Sound\Win", "SoundDriver", "4"); // Force XAudio
 				ini.WriteValue(@"Sound\Win", "BufferSize", "64");
 
-				ini.WriteValue(@"Display\Win", "OutputMethod", "2"); // Force OpenGL renderer to get bezel and shader to work
+				//ini.WriteValue(@"Display\Win", "OutputMethod", "2"); // Force OpenGL renderer to get bezel and shader to work
 				ini.WriteValue(@"Display\Win", "HideMenu", "TRUE"); // Hide menu at startup, ESC to toggle
 				ini.WriteValue(@"Display\Win", "FullscreenOnOpen", "FALSE");
 				ini.WriteValue(@"Display\Win", "Fullscreen:Enabled", fullscreen ? "TRUE" : "FALSE");
@@ -109,12 +114,14 @@ namespace EmulatorLauncher
 				ini.WriteValue(@"Display\Win", "BlendHiRes", "TRUE");
 
 				// Bilinear filtering
+
 				if (SystemConfig.isOptSet("snes9x_bilinear") && SystemConfig.getOptBoolean("snes9x_bilinear"))
 					ini.WriteValue(@"Display\Win", "Stretch:BilinearFilter", "TRUE");
 				else
 					ini.WriteValue(@"Display\Win", "Stretch:BilinearFilter", "FALSE");
 
 				// Ratio
+
 				if (SystemConfig.isOptSet("snes9x_ratio") && !string.IsNullOrEmpty(SystemConfig["snes9x_ratio"]))
                 {
 
@@ -136,46 +143,99 @@ namespace EmulatorLauncher
 				}
 
 				// Integer scale
+
 				if (SystemConfig.isOptSet("snes9x_integer") && SystemConfig.getOptBoolean("snes9x_integer"))
 					ini.WriteValue(@"Display\Win", "Stretch:IntegerScaling", "TRUE");
 				else
 					ini.WriteValue(@"Display\Win", "Stretch:IntegerScaling", "FALSE");
 
 				// VSync
+
 				if (SystemConfig.isOptSet("snes9x_vsync") && !SystemConfig.getOptBoolean("snes9x_vsync"))
 					ini.WriteValue(@"Display\Win", "Vsync", "FALSE");
 				else
 					ini.WriteValue(@"Display\Win", "Vsync", "TRUE");
 
 				// NTSC filters
+
 				if (SystemConfig.isOptSet("snes9x_ntsc_filters") && !string.IsNullOrEmpty(SystemConfig["snes9x_ntsc_filters"]))
 					ini.WriteValue(@"Display\Win", "FilterType", SystemConfig["snes9x_ntsc_filters"]);
 				else
 					ini.WriteValue(@"Display\Win", "FilterType", "0");
 
+				// Video drivers
+
+				if (SystemConfig.isOptSet("snes9x_renderer") && !string.IsNullOrEmpty(SystemConfig["snes9x_renderer"]))
+                {
+					if (SystemConfig["snes9x_renderer"] == "opengl")
+						ini.WriteValue(@"Display\Win", "OutputMethod", "2");
+					else if (SystemConfig["snes9x_renderer"] == "vulkan")
+						ini.WriteValue(@"Display\Win", "OutputMethod", "3");				
+
+				}
+				else
+					ini.WriteValue(@"Display\Win", "OutputMethod", "2");
+
+
 				// Shaders
+
 				if (SystemConfig.isOptSet("snes9x_shader") && !string.IsNullOrEmpty(SystemConfig["snes9x_shader"]))
                 {
 					ini.WriteValue(@"Display\Win", "ShaderEnabled", "TRUE");
 					ini.WriteValue(@"Display\Win", "NTSCScanlines", "TRUE");
 
-					string shaderPath = Path.Combine(path, "shaders", "shaders_glsl", SystemConfig["snes9x_shader"]);
-					if (!File.Exists(shaderPath))
+					if (SystemConfig["snes9x_shader"].Contains(".glslp"))
+                    {
 						shaderPath = Path.Combine(AppConfig.GetFullPath("retroarch"), "shaders", "shaders_glsl", SystemConfig["snes9x_shader"]);
-					if (!File.Exists(shaderPath))
-						shaderPath = Path.Combine(AppConfig.GetFullPath("system"), "shaders", "shaders_glsl", SystemConfig["snes9x_shader"]);
-					if (File.Exists(shaderPath))
-						ini.WriteValue(@"Display\Win", "OpenGL:OGLShader", shaderPath);
+						ini.WriteValue(@"Display\Win", "OutputMethod", "2");
+
+						if (File.Exists(shaderPath))
+							ini.WriteValue(@"Display\Win", "OpenGL:OGLShader", shaderPath);
+						else
+							ini.WriteValue(@"Display\Win", "OpenGL:OGLShader", "");
+					}					
+					else if (SystemConfig["snes9x_shader"].Contains(".slangp"))
+                    {
+						shaderPath = Path.Combine(AppConfig.GetFullPath("retroarch"), "shaders", "shaders_slang", SystemConfig["snes9x_shader"]);
+						ini.WriteValue(@"Display\Win", "OutputMethod", "3");
+
+						if (File.Exists(shaderPath))
+							ini.WriteValue(@"Display\Win", "OpenGL:OGLShader", shaderPath);
+						else
+							ini.WriteValue(@"Display\Win", "OpenGL:OGLShader", "");
+					}						
 					else
-						ini.WriteValue(@"Display\Win", "OpenGL:OGLShader", "");                 
-                }
+                    {
+						if (SystemConfig["snes9x_renderer"] == "opengl")
+                        {
+							shaderPath = Path.Combine(AppConfig.GetFullPath("retroarch"), "shaders", "shaders_glsl", SystemConfig["snes9x_shader"] + ".glslp");
+
+							if (File.Exists(shaderPath))
+								ini.WriteValue(@"Display\Win", "OpenGL:OGLShader", shaderPath);
+							else
+								ini.WriteValue(@"Display\Win", "OpenGL:OGLShader", "");
+
+						}
+						else if (SystemConfig["snes9x_renderer"] == "vulkan")
+                        {
+							shaderPath = Path.Combine(AppConfig.GetFullPath("retroarch"), "shaders", "shaders_slang", SystemConfig["snes9x_shader"] + ".slangp");
+
+							if (File.Exists(shaderPath))
+								ini.WriteValue(@"Display\Win", "OpenGL:OGLShader", shaderPath);
+							else
+								ini.WriteValue(@"Display\Win", "OpenGL:OGLShader", "");
+						}
+								
+					}
+
+				}
                 else
                 {
 					ini.WriteValue(@"Display\Win", "ShaderEnabled", "FALSE");
 					ini.WriteValue(@"Display\Win", "NTSCScanlines", "FALSE");
-					ini.WriteValue(@"Display\Win", "OpenGL:OGLShader", "");
-				}            
-				
+				}
+
+
 			}
 
         }


### PR DESCRIPTION
use retroarch shaders
when shader extension is specified in choice of feature, it will auto use opengl video driver if it's .glslp or vulkan if it's .slangp. If no extension, it will use default or selected video driver