### PR TITLE
MAME, Snes9X, Sinden

### DIFF
--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -2389,6 +2389,10 @@
         <choice name="NO" value="disabled"/>
         <choice name="YES" value="enabled"/>
       </feature>
+      <feature submenu="CONTROLS" name="DISABLE MOUSE" group="ADVANCED SETTINGS" value="mame_mouse_enable">
+        <choice name="NO" value="enabled"/>
+        <choice name="YES" value="disabled"/>
+      </feature>
       <feature submenu="GUNS" name="LIGHTGUN MODE" group="ADVANCED SETTINGS" value="lightgun_mode">
         <choice name="NO" value="none"/>
         <choice name="TOUCHSCREEN" value="touchscreen"/>

--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -12970,12 +12970,14 @@
     <sharedFeature group="GENERAL SETTINGS" value="disableautocontrollers"/>
     <sharedFeature submenu="VIDEO" group="ADVANCED SETTINGS" value="videomode"/>
     <sharedFeature submenu="VIDEO" group="ADVANCED SETTINGS" value="forcefullscreen"/>
-    <feature submenu="VIDEO" name="EMULATED VIDEO SIGNAL" group="ADVANCED SETTINGS" value="snes9x_ntsc_filters" description="Apply a video filter to mimic various signals.">
+    <feature submenu="VISUAL RENDERING" name="OUTPUT FILTER" group="ADVANCED SETTINGS" value="snes9x_ntsc_filters" description="Apply a video filter to the output image.">
       <choice name="NONE" value="0"/>
-      <choice name="RF" value="5"/>
-      <choice name="COMPOSITE" value="6"/>
-      <choice name="S-VIDEO" value="7"/>
-      <choice name="RGB" value="8"/>
+      <choice name="Blargg's NTSC (RF)" value="5"/>
+      <choice name="Blargg's NTSC (Composite)" value="6"/>
+      <choice name="Blargg's NTSC (S-Video)" value="7"/>
+      <choice name="Blargg's NTSC (RGB)" value="8"/>
+      <choice name="hq4x" value="27"/>
+      <choice name="6xBRZ" value="32"/>
     </feature>
     <feature submenu="DRIVER" name="VIDEO" group="ADVANCED SETTINGS" value="snes9x_renderer">
       <choice name="OPENGL" value="opengl"/>

--- a/EmulatorLauncher.Common/Lightguns/RawLightGun.cs
+++ b/EmulatorLauncher.Common/Lightguns/RawLightGun.cs
@@ -32,14 +32,14 @@ namespace EmulatorLauncher.Common.Lightguns
 
         public static bool IsSindenLightGunConnected()
         {
-            // Find Sinden process
+            // Find Sinden software process (if software is not running , no need to check for the gun and no need to create the border)
             var px = Process.GetProcessesByName("Lightgun").FirstOrDefault();
             if (px == null)
                 return false;
 
-            // When Sinden Lightgun app is running & Start is pressed, there's an ActiveMovie window in the process, with the class name "FilterGraphWindow"
+            /* When Sinden Lightgun app is running & Start is pressed, there's an ActiveMovie window in the process, with the class name "FilterGraphWindow" --- disabled for now but kept in case we need it later
             if (!User32.FindHwnds(px.Id, hWnd => User32.GetClassName(hWnd) == "FilterGraphWindow", false).Any())
-                return false;
+                return false;*/
 
             // Check if any Sinden Gun is connected
             return RawLightgun.GetRawLightguns().Any(gun => gun.Type == RawLighGunType.SindenLightgun);

--- a/emulatorLauncher/Generators/LibRetro.CoreOptions.cs
+++ b/emulatorLauncher/Generators/LibRetro.CoreOptions.cs
@@ -1703,9 +1703,13 @@ namespace EmulatorLauncher.Libretro
             coreSettings["mame_softlists_enable"] = softLists;
             coreSettings["mame_softlists_auto_media"] = softLists;
             coreSettings["mame_write_config"] = "disabled";
-            coreSettings["mame_mouse_enable"] = "enabled";
             coreSettings["mame_mame_paths_enable"] = "disabled";
 
+            if (SystemConfig.isOptSet("mame_lightgun_mode") && SystemConfig["mame_lightgun_mode"] != "none")
+                coreSettings["mame_mouse_enable"] = "disabled";
+            else
+                BindFeature(coreSettings, "mame_mouse_enable", "mame_mouse_enable", "enabled");
+            
             BindFeature(coreSettings, "mame_buttons_profiles", "mame_buttons_profiles", "disabled");
             BindFeature(coreSettings, "mame_read_config", "mame_read_config", "disabled");
             BindFeature(coreSettings, "mame_alternate_renderer", "alternate_renderer", "disabled");

--- a/emulatorLauncher/Generators/LibRetro.Guns.cs
+++ b/emulatorLauncher/Generators/LibRetro.Guns.cs
@@ -48,11 +48,15 @@ namespace EmulatorLauncher.Libretro
 
             int gunCount = RawLightgun.GetUsableLightGunCount();
             var guns = RawLightgun.GetRawLightguns();
+            SimpleLogger.Instance.Info("[LightGun] Found " + gunCount + " usable guns.");
 
             // Set multigun to true in some cases
             // Case 1 = multiple guns are connected, playerindex is 1 and user did not force 'one gun only'
             if (gunCount > 1 && guns.Length > 1 && playerIndex == 1 && !useOneGun)
+            {
+                SimpleLogger.Instance.Info("[LightGun] Multigun enabled.");
                 multigun = true;
+            }
 
             // Single player - assign buttons of joystick linked with playerIndex to gun buttons
             if (!multigun)
@@ -123,7 +127,7 @@ namespace EmulatorLauncher.Libretro
 
                     int deviceIndex = guns[i - 1].Index; // i-1;
 
-                    SimpleLogger.Instance.Debug("[LightGun] Assigned player " + i + " to -> " + guns[i - 1].ToString());
+                    SimpleLogger.Instance.Info("[LightGun] Assigned player " + i + " to -> " + guns[i-1].Name.ToString() + " index: " + guns[i-1].Index.ToString());
 
                     retroarchConfig["input_libretro_device_p" + i] = deviceType;
                     retroarchConfig["input_player" + i + "_mouse_index"] = deviceIndex.ToString();
@@ -270,14 +274,9 @@ namespace EmulatorLauncher.Libretro
             // If option in ES is forced to use one gun, only one gun will be configured on the playerIndex defined for the core
             if (useOneGun || playerIndex == 2)
             {
-                // First gun will be used
-                int deviceIndex = guns[0].Index;
-
-                SimpleLogger.Instance.Debug("[LightGun] Assigned player " + playerIndex + " to -> " + guns[0].ToString());
-
                 // Set deviceType and DeviceIndex
                 retroarchConfig["input_libretro_device_p" + playerIndex] = deviceType;
-                retroarchConfig["input_player" + playerIndex + "_mouse_index"] = deviceIndex.ToString();
+                retroarchConfig["input_player" + playerIndex + "_mouse_index"] = "0";
 
                 // Set mouse buttons (mouse only has 3 buttons, that can be mapped differently for each core)
                 retroarchConfig["input_player" + playerIndex + "_gun_trigger_mbtn"] = guninvert ? "2" : "1";
@@ -385,7 +384,7 @@ namespace EmulatorLauncher.Libretro
                 {
                     int deviceIndex = guns[i - 1].Index; // i-1;
 
-                    SimpleLogger.Instance.Debug("[LightGun] Assigned player " + i + " to -> " + guns[i - 1].ToString());
+                    SimpleLogger.Instance.Info("[LightGun] Assigned player " + i + " to -> " + guns[i-1].Name.ToString() + " index: " + guns[i-1].Index.ToString());
 
                     retroarchConfig["input_libretro_device_p" + i] = deviceType;
                     retroarchConfig["input_player" + i + "_mouse_index"] = deviceIndex.ToString();

--- a/emulatorLauncher/Generators/Mame64.Controllers.cs
+++ b/emulatorLauncher/Generators/Mame64.Controllers.cs
@@ -46,7 +46,7 @@ namespace EmulatorLauncher
             foreach (var controller in mameControllers)
             {
                 int i = controller.PlayerIndex;
-                int cIndex = controller.DirectInput != null ? controller.DirectInput.DeviceIndex + 1 : controller.DeviceIndex + 1;
+                int cIndex = controller.DeviceIndex + 1;
                 string joy = "JOYCODE_" + cIndex + "_";
                 bool dpadonly = SystemConfig.isOptSet("mame_dpadandstick") && SystemConfig.getOptBoolean("mame_dpadandstick");
                 bool isXinput = controller.IsXInputDevice && SystemConfig["mame_joystick_driver"] != "dinput";
@@ -57,11 +57,10 @@ namespace EmulatorLauncher
 
                 if (SystemConfig["mame_joystick_driver"] == "xinput")
                 {
-                    cIndex = mameControllers.IndexOf(controller) + 1;
-                    input.Add(new XElement("mapdevice", new XAttribute("device", "Xinput Player " + cIndex), new XAttribute("controller", "JOYCODE_" + cIndex)));
+                    int xIndex = mameControllers.OrderBy(c => c.DeviceIndex).ToList().IndexOf(controller) + 1;
+                    joy = "JOYCODE_" + xIndex + "_";
+                    input.Add(new XElement("mapdevice", new XAttribute("device", "XInput Player " + xIndex), new XAttribute("controller", "JOYCODE_" + xIndex)));
                 }
-
-                SimpleLogger.Instance.Info("[INFO] Joystick for player " + i + " identified as " + (isXinput ? "XINPUT" : "DINPUT") + " device number " + cIndex);
 
                 // Get dinput mapping information
                 if (!isXinput)

--- a/emulatorLauncher/Generators/Mame64.Generator.cs
+++ b/emulatorLauncher/Generators/Mame64.Generator.cs
@@ -161,9 +161,6 @@ namespace EmulatorLauncher
                 /// -crosshairpath
                 /// -swpath
 
-                if (!SystemConfig.isOptSet("read_ini") || !SystemConfig.getOptBoolean("read_ini"))
-                    commandArray.Add("-noreadconfig");
-
                 commandArray.AddRange(GetCommonMame64Arguments(rom, hbmame, resolution));
 
                 // Unknown system, try to run with rom name only
@@ -193,6 +190,9 @@ namespace EmulatorLauncher
         private List<string> GetCommonMame64Arguments(string rom, bool hbmame, ScreenResolution resolution = null)
         {
             var retList = new List<string>();
+
+            if (!SystemConfig.isOptSet("read_ini") || !SystemConfig.getOptBoolean("read_ini"))
+                retList.Add("-noreadconfig");
 
             string sstatePath = Path.Combine(AppConfig.GetFullPath("saves"), "mame", "states");
             if (!Directory.Exists(sstatePath)) try { Directory.CreateDirectory(sstatePath); }
@@ -551,7 +551,6 @@ namespace EmulatorLauncher
             }
 
             // Add code here
-
 
             return retList;
         }

--- a/emulatorLauncher/Generators/TeknoParrot.generator.cs
+++ b/emulatorLauncher/Generators/TeknoParrot.generator.cs
@@ -303,6 +303,8 @@ namespace EmulatorLauncher
             else
                 data.UseDiscordRPC = false;
 
+            data.CheckForUpdates = false;
+
             File.WriteAllText(parrotData, data.ToXml());
         }
 


### PR DESCRIPTION
- MAME : XInput driver with PlayerIndex
- Snes9x filter option renaming
- Fix retroarch gun index when ONLY 1 GUN
- Option in libretro:mame to disable MOUSE
- Sinden detection : remove check on "FilterGraphWindow"
- Disable teknoparrot update check