### PR TITLE
PCSX2, PSXMAME, T300 wheel

### DIFF
--- a/emulatorLauncher/Generators/LibRetro.Generator.cs
+++ b/emulatorLauncher/Generators/LibRetro.Generator.cs
@@ -9,6 +9,7 @@ using System.Drawing;
 using System.Globalization;
 using EmulatorLauncher.Common;
 using EmulatorLauncher.Common.FileFormats;
+using EmulatorLauncher.Common.Lightguns;
 
 namespace EmulatorLauncher.Libretro
 {
@@ -51,13 +52,25 @@ namespace EmulatorLauncher.Libretro
             retroarchConfig["notification_show_config_override_load"] = "false";            
             retroarchConfig["notification_show_remap_load"] = "false";
             retroarchConfig["driver_switch_enable"] = "true";
-            retroarchConfig["input_driver"] = "dinput";
-            BindBoolFeature(retroarchConfig, "pause_on_disconnect", "pause_on_disconnect", "true", "false");
-
             retroarchConfig["rgui_extended_ascii"] = "true";
             retroarchConfig["rgui_show_start_screen"] = "false";
             retroarchConfig["rgui_browser_directory"] = AppConfig.GetFullPath("roms") ?? "default";
             
+            // input driver set to raw if multigun is enabled
+            if (SystemConfig.getOptBoolean("use_guns") && !SystemConfig.getOptBoolean("one_gun"))
+            {
+                int gunCount = RawLightgun.GetUsableLightGunCount();
+                var guns = RawLightgun.GetRawLightguns();
+
+                if (gunCount > 1 && guns.Length > 1)
+                    retroarchConfig["input_driver"] = "raw";
+                else
+                    retroarchConfig["input_driver"] = "dinput";
+            }
+            else
+                retroarchConfig["input_driver"] = "dinput";
+            
+            BindBoolFeature(retroarchConfig, "pause_on_disconnect", "pause_on_disconnect", "true", "false");
             BindBoolFeature(retroarchConfig, "pause_nonactive", "use_guns", "true", "false", true); // Pause when calibrating gun...
             BindBoolFeature(retroarchConfig, "input_autodetect_enable", "disableautocontrollers", "true", "false", true);
             BindFeature(retroarchConfig, "input_analog_deadzone", "analog_deadzone", "0.000000");

--- a/emulatorLauncher/Generators/LibRetro.Guns.cs
+++ b/emulatorLauncher/Generators/LibRetro.Guns.cs
@@ -61,6 +61,7 @@ namespace EmulatorLauncher.Libretro
             // Single player - assign buttons of joystick linked with playerIndex to gun buttons
             if (!multigun)
             {
+                retroarchConfig["input_driver"] = "dinput";
                 // Get gamepad buttons to assign them so that controller buttons can be used along with gun
                 string a_padbutton = retroarchConfig["input_player" + playerIndex + "_a_btn"];
                 string b_padbutton = retroarchConfig["input_player" + playerIndex + "_b_btn"];
@@ -274,6 +275,7 @@ namespace EmulatorLauncher.Libretro
             // If option in ES is forced to use one gun, only one gun will be configured on the playerIndex defined for the core
             if (useOneGun || playerIndex == 2)
             {
+                retroarchConfig["input_driver"] = "dinput";
                 // Set deviceType and DeviceIndex
                 retroarchConfig["input_libretro_device_p" + playerIndex] = deviceType;
                 retroarchConfig["input_player" + playerIndex + "_mouse_index"] = "0";
@@ -380,6 +382,7 @@ namespace EmulatorLauncher.Libretro
             // Multigun case
             else
             {
+                retroarchConfig["input_driver"] = "raw";
                 for (int i = 1; i <= guns.Length; i++)
                 {
                     int deviceIndex = guns[i - 1].Index; // i-1;

--- a/emulatorLauncher/Generators/Model3.Controllers.cs
+++ b/emulatorLauncher/Generators/Model3.Controllers.cs
@@ -1652,6 +1652,10 @@ namespace EmulatorLauncher
                 int buttonID = (button.Substring(7).ToInteger()) + 1;
                 return "\"JOY" + index + "_BUTTON" + buttonID + "\"";
             }
+            
+            else if (button.StartsWith("dp"))
+                return "\"" + GetDinputMapping(index, wheel, button) + "\"";
+
             else
             {
                 switch (button)

--- a/emulatorLauncher/Generators/PSXMame.Generator.cs
+++ b/emulatorLauncher/Generators/PSXMame.Generator.cs
@@ -154,6 +154,8 @@ namespace EmulatorLauncher
             string iniFile = Path.Combine(path, "mame.ini");
             iniFiles.Add(iniFile);
 
+            string nvramPath = Path.Combine(AppConfig.GetFullPath("saves"), "psxmame", "nvram");
+
             foreach (string file in iniFiles)
             {
                 var ini = PSXMameIniFile.FromFile(file);
@@ -163,6 +165,7 @@ namespace EmulatorLauncher
                 ini["ctrlrpath"] = "ctrlr";
                 ini["inipath"] = ".;ini";
                 ini["cfg_directory"] = "cfg";
+                ini["nvram_directory"] = nvramPath;
 
                 // Core state options
                 ini["snapname"] = "%g/%i";

--- a/emulatorLauncher/Generators/PSXMame.Generator.cs
+++ b/emulatorLauncher/Generators/PSXMame.Generator.cs
@@ -96,13 +96,17 @@ namespace EmulatorLauncher
                 commandArray.Add(sstatePath);
             }
 
+            string ctrlrPath = Path.Combine(path, "ctrlr");
+            if (!Directory.Exists(ctrlrPath)) try { Directory.CreateDirectory(ctrlrPath); }
+                catch { }
+
             if (SystemConfig["psxmame_controller_configmode"] == "per_game" && File.Exists(Path.Combine(path, "ctrlr", Path.GetFileNameWithoutExtension(rom) + ".cfg")))
             {
                 commandArray.Add("-ctrlr");
                 commandArray.Add(Path.GetFileNameWithoutExtension(rom));
             }
 
-            else if (!Program.SystemConfig.isOptSet("disableautocontrollers") || Program.SystemConfig["disableautocontrollers"] == "0")
+            else if (ConfigureMameControllers(path))
             {
                 commandArray.Add("-ctrlr");
                 commandArray.Add("retrobat");
@@ -116,7 +120,6 @@ namespace EmulatorLauncher
 
             ConfigureUIini(Path.Combine(path));
             ConfigureMameini(Path.Combine(path), combinedRomPath);
-            ConfigureMameControllers(path);
 
             return new ProcessStartInfo()
             {

--- a/emulatorLauncher/Generators/Pcsx2.Generator.cs
+++ b/emulatorLauncher/Generators/Pcsx2.Generator.cs
@@ -695,7 +695,8 @@ namespace EmulatorLauncher
             if (SystemConfig.getOptBoolean("disableautoconfig"))
                 return;
 
-            var biosList = new string[] { "ps2-0230a-20080220.bin", "ps2-0230e-20080220.bin", "ps2-0250e-20100415.bin", "ps2-0230j-20080220.bin", "ps3_ps2_emu_bios.bin" };
+            var biosList = new string[] { "ps2-0230a-20080220.bin", "ps2-0230e-20080220.bin", "ps2-0250e-20100415.bin", "ps2-0230j-20080220.bin", "ps3_ps2_emu_bios.bin", 
+                "SCPH30004R.bin", "scph39001.bin", "SCPH-39004_BIOS_V7_EUR_160.BIN", "SCPH-39001_BIOS_V7_USA_160.BIN", "SCPH-70000_BIOS_V12_JAP_200.BIN" };
 
             string conf = Path.Combine(_path, "inis", "PCSX2.ini");
 
@@ -747,20 +748,29 @@ namespace EmulatorLauncher
                 if (!Directory.Exists(biosPath))
                     try { Directory.CreateDirectory(biosPath); }
                     catch { }
-                ini.WriteValue("Folders", "Bios", biosPath);
 
                 string biosFile = "ps2-0230a-20080220.bin";                     // Default bios
+
+                if (Directory.GetFiles(biosPath).Length == 0)                 // if no bios, do not set
+                    biosPath = AppConfig.GetFullPath("bios");
+                
+                if (!biosList.Any(b => File.Exists(Path.Combine(biosPath, b))))
+                    throw new ApplicationException("No BIOS found in bios/pcsx2/bios folder.");
 
                 if (!File.Exists(Path.Combine(biosPath, biosFile)))             // if default does not exist, select first one that exists
                     biosFile = biosList.FirstOrDefault(b => File.Exists(Path.Combine(biosPath, b)));
 
                 if (SystemConfig.isOptSet("pcsx2_forcebios") && !string.IsNullOrEmpty(SystemConfig["pcsx2_forcebios"]))                         // Precise bios to use through feature
-                    biosFile = SystemConfig["pcsx2_forcebios"];
+                {
+                    string checkBiosFile = Path.Combine(biosPath, SystemConfig["pcsx2_forcebios"]);
+                    if (File.Exists(checkBiosFile))
+                        biosFile = SystemConfig["pcsx2_forcebios"];
+                }
 
-                if (string.IsNullOrEmpty(biosFile))
-                    throw new ApplicationException("No PS2 BIOS found.");
+                ini.WriteValue("Folders", "Bios", biosPath);
 
-                ini.WriteValue("Filenames", "BIOS", biosFile);
+                if (!string.IsNullOrEmpty(biosFile))
+                    ini.WriteValue("Filenames", "BIOS", biosFile);
 
                 // Cheats Path
                 var cheatsRootPath = AppConfig.GetFullPath("cheats");

--- a/emulatorLauncher/Resources/wheelMapping.yml
+++ b/emulatorLauncher/Resources/wheelMapping.yml
@@ -186,10 +186,10 @@ ThrustmasterT300RS:
   Gear5: nul
   Gear6: nul
   Gear_reverse: nul
-  DpadUp: button_13
-  DpadDown: button_14
-  DpadLeft: button_15
-  DpadRight: button_16
+  DpadUp: dpup
+  DpadDown: dpdown
+  DpadLeft: dpleft
+  DpadRight: dpright
 default:
   WheelGuid: nul
   Inputsystems: sdl,xinput,dinput


### PR DESCRIPTION
- PCSX2 bioscheck (check in bios\ if nothing found in bios\pcsx2\bios and also allow old bioses
- T300RS ==> fix values for dpad
- Fix nvram path for PSXMAME
- Allow switch to "raw" in libretro as soon as there is 'use_guns' and multiple guns connected, even if the core does not have "SetupLightgun" in coreoptions !