### PR TITLE
add gemrb engine compatiblity and its first features integration

### DIFF
--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -9754,6 +9754,54 @@
       <choice name="NO" value="0"/>
     </feature>
   </emulator>
+  <!-- GEMRB -->
+  <emulator name="gemrb">
+    <feature name="INTERNAL RESOLUTION" value="resolution" group="GENERAL SETTINGS" description="Depending on games, higher resolution than 640x480 might not work. You maybe need to install a widescreen mod. Type a resolution like '1920x1080' or 'desktop' to run a game with your desktop resolution or leave empty for game's native res." preset="input"/>
+    <feature name="LANGUAGE ENCODING" group="GENERAL SETTINGS" value="Encoding" description="Specific language font encoding used by the game.">
+      <choice name="DEFAULT" value="default"/>
+      <choice name="GERMAN" value="german"/>
+      <choice name="POLISH" value="polish"/>
+      <choice name="CZECH" value="czech"/>
+    </feature>
+    <feature submenu="VISUAL RENDERING" name="FOG OF WAR" group="ADVANCED SETTINGS" value="SpriteFogOfWar" description="For nostalgia. By default it looks like accelerated FoW in BG2">
+      <choice name="ACCELERATED" value="0"/>
+      <choice name="SPRITE" value="1"/>
+    </feature>
+    <feature submenu="VISUAL RENDERING" name="BITS PER PIXEL" group="ADVANCED SETTINGS" value="Bpp">
+      <choice name="32" value="32"/>
+      <choice name="16" value="16"/>
+    </feature>
+    <sharedFeature submenu="VIDEO" group="ADVANCED SETTINGS" value="forcefullscreen"/>
+    <feature submenu="DEBUG" name="LOGGING" group="ADVANCED SETTINGS" value="Logging">
+      <choice name="ON" value="1"/>
+      <choice name="OFF" value="0"/>
+    </feature>
+    <feature submenu="DEBUG" name="SHOW FPS" group="ADVANCED SETTINGS" value="DrawFPS">
+      <choice name="ON" value="1"/>
+      <choice name="OFF" value="0"/>
+    </feature>
+    <feature submenu="DEBUG" name="VIDEO INTRO" group="ADVANCED SETTINGS" value="SkipIntroVideos">
+      <choice name="ON" value="1"/>
+      <choice name="OFF" value="0"/>
+    </feature>
+    <feature submenu="DEBUG" name="CHEAT KEYS" group="ADVANCED SETTINGS" value="EnableCheatKeys">
+      <choice name="ON" value="1"/>
+      <choice name="OFF" value="0"/>
+    </feature>
+    <feature submenu="DEBUG" name="DEVELOPER MODE" group="ADVANCED SETTINGS" value="DebugMode">
+      <choice name="OFF" value="0"/>
+      <choice name="count references" value="1"/>
+      <choice name="display cutscene warnings" value="2"/>
+      <choice name="display variable warnings" value="4"/>
+      <choice name="display action warnings" value="8"/>
+      <choice name="display trigger warnings" value="16"/>
+      <choice name="enable views debug mode" value="32"/>
+      <choice name="enable window debug mode" value="64"/>
+      <choice name="enable font debug mode" value="128"/>
+      <choice name="enable text debug mode" value="256"/>
+      <choice name="enable pathfinding debug mode" value="512"/>
+    </feature>
+  </emulator>
   <!-- GSPLUS -->
   <emulator name="gsplus" features="padtokeyboard">
     <sharedFeature group="GENERAL SETTINGS" value="shaderset"/>

--- a/emulatorLauncher/Generators/GemRB.Generator.cs
+++ b/emulatorLauncher/Generators/GemRB.Generator.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.IO;
+using System.Diagnostics;
+using System.Threading;
+using EmulatorLauncher.Common;
+using EmulatorLauncher.Common.EmulationStation;
+using EmulatorLauncher.Common.FileFormats;
+using EmulatorLauncher.PadToKeyboard;
+using System.Windows.Forms;
+
+namespace EmulatorLauncher
+{
+    partial class GemRBGenerator : Generator
+    {
+        private ScreenResolution _resolution;
+
+        public override System.Diagnostics.ProcessStartInfo Generate(string system, string emulator, string core, string rom, string playersControllers, ScreenResolution resolution)
+        {
+            string path = AppConfig.GetFullPath("gemrb");
+
+            string exe = Path.Combine(path, "gemrb.exe");
+            if (!File.Exists(exe))
+                return null;
+
+            string conf = Path.Combine(path, "GemRB.cfg");
+            if (!File.Exists(exe))
+                return null;
+
+            bool fullscreen = !IsEmulationStationWindowed() || SystemConfig.getOptBoolean("forcefullscreen");
+
+            _resolution = resolution;
+
+            SetupConfiguration(path, rom, conf, system, fullscreen, resolution);
+
+            return new ProcessStartInfo()
+            {
+                FileName = exe,
+                WorkingDirectory = path,
+                Arguments = "-c \"" + conf + "\"",
+            };
+        }
+
+        private void SetupConfiguration(string path, string rom, string conf, string system, bool fullscreen, ScreenResolution resolution)
+        {
+            string gamePath = AppConfig.GetFullPath(rom);          
+            string gameExtension = Path.GetExtension(rom).Replace(".", "");
+            string gameName = new DirectoryInfo(gamePath).Name.Replace("." + gameExtension, "");
+
+            string savesPath = Path.Combine(AppConfig.GetFullPath("saves"), system, gameName);
+            if (!Directory.Exists(savesPath)) try { Directory.CreateDirectory(savesPath); }
+                catch { }
+
+            using (var ini = IniFile.FromFile(conf))
+            {                
+                ini.WriteValue("", "GameType", gameExtension);
+                ini.WriteValue("", "Fullscreen", fullscreen ? "1" : "0");
+                ini.WriteValue("", "GamePath", gamePath);
+                ini.WriteValue("", "SavePath", savesPath);
+                ini.WriteValue("", "AudioDriver", "openal");
+                ini.WriteValue("", "CapFPS", "0");
+
+                if (SystemConfig.isOptSet("resolution") && !string.IsNullOrEmpty(SystemConfig["resolution"]))
+                {                                       
+
+                    if (SystemConfig["resolution"].ToLower().Contains("x"))
+                    {
+                        string[] gameResolution = SystemConfig["resolution"].ToLower().Split('x');
+                        ini.WriteValue("", "Width", gameResolution[0]);
+                        ini.WriteValue("", "Height", gameResolution[1]);
+
+                    }
+                    else if (SystemConfig["resolution"].ToLower() == "desktop")
+                    {
+                        ini.WriteValue("", "Width", (resolution == null ? Screen.PrimaryScreen.Bounds.Width : resolution.Width).ToString());
+                        ini.WriteValue("", "Height", (resolution == null ? Screen.PrimaryScreen.Bounds.Height : resolution.Height).ToString());
+                    }
+                    else
+                    {
+                        ini.WriteValue("", "Width", "640");
+                        ini.WriteValue("", "Height", "480");
+                    }
+                }
+                else
+                {
+                    ini.WriteValue("", "Width", "640");
+                    ini.WriteValue("", "Height", "480");
+                }
+
+                BindIniFeature(ini, "", "Logging", "Logging", "0");
+                BindIniFeature(ini, "", "SkipIntroVideos", "SkipIntroVideos", "0");
+                BindIniFeature(ini, "", "DrawFPS", "DrawFPS", "0");
+                BindIniFeature(ini, "", "EnableCheatKeys", "EnableCheatKeys", "0");
+                BindIniFeature(ini, "", "DebugMode", "DebugMode", "0");
+                BindIniFeature(ini, "", "Encoding", "Encoding", "default");
+                BindIniFeature(ini, "", "Bpp", "Bpp", "32");
+                BindIniFeature(ini, "", "DebugMode", "DebugMode", "0");
+                BindIniFeature(ini, "", "SpriteFogOfWar", "SpriteFogOfWar", "0");
+
+            }
+
+        }
+
+        public override int RunAndWait(ProcessStartInfo path)
+        {
+            int ret = base.RunAndWait(path);
+            return ret;
+        }
+    }
+}

--- a/emulatorLauncher/Installer.cs
+++ b/emulatorLauncher/Installer.cs
@@ -95,6 +95,7 @@ namespace EmulatorLauncher
             { new Installer("gzdoom", "gzdoom", "gzdoom.exe") },
             { new Installer("magicengine", "magicengine", "pce.exe") },
             { new Installer("eka2l1", "eka2l1", "eka2l1_qt.exe") },
+            { new Installer("gemrb", "gemrb", "gemrb.exe") },
             { new Installer("psxmame", "psxmame", "mame.exe") }
         };
 

--- a/emulatorLauncher/Program.cs
+++ b/emulatorLauncher/Program.cs
@@ -113,6 +113,7 @@ namespace EmulatorLauncher
             { "kronos", () => new KronosGenerator() },
             { "gzdoom", () => new GZDoomGenerator() },
             { "magicengine", () => new MagicEngineGenerator() },
+            { "gemrb", () => new GemRBGenerator() },
             { "psxmame", () => new PSXMameGenerator() }
         };
 

--- a/emulatorLauncher/emulatorLauncher.csproj
+++ b/emulatorLauncher/emulatorLauncher.csproj
@@ -177,6 +177,7 @@
     </Compile>
     <Compile Include="Generators\ForceEngine.Generator.cs" />
     <Compile Include="Generators\Fpinball.Generator.cs" />
+    <Compile Include="Generators\GemRB.Generator.cs" />
     <Compile Include="Generators\GsPlus.Generator.cs" />
     <Compile Include="Generators\GzDoom.Generator.cs" />
     <Compile Include="Generators\Hatari.Generator.cs" />


### PR DESCRIPTION
GemRB need the original games (not Enhanced Edition from Beamdog). They need to be copied in roms\gemrb and in a subfolder with an extension in its name. (e.g "roms\gemrb\Baldur's Gate.bg1"). Then simply run the game from EmulationStation.