### PR TITLE
Add feature on Xenia

### DIFF
--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -13182,6 +13182,7 @@
     <feature submenu="EMULATION" name="SCRIBBLE HEAP" group="ADVANCED SETTINGS" value="scribble_heap" description="Scribble 0xCD into all allocated heap memory." preset="switchauto"/>
     <feature submenu="EMULATION" name="PROTECT ZERO" group="ADVANCED SETTINGS" value="protect_zero" description="Hack needed for some games." preset="switchauto"/>
     <feature submenu="EMULATION" name="ENABLE D3D DEBUG LAYER" group="ADVANCED SETTINGS" value="xenia_d3d12_debug" description="Hack needed for some games (Too Human)." preset="switchauto"/>
+    <feature submenu="EMULATION" name="BREAK ON UNIMPLEMENTED INSTRUCTIONS" group="ADVANCED SETTINGS" value="break_on_unimplemented_instructions" description="Break to the host debugger (or crash if no debugger attached) if an unimplemented PowerPC instruction is encountered." preset="switchauto"/>
     <feature submenu="DRIVERS" name="VIDEO" group="ADVANCED SETTINGS" value="gpu">
       <choice name="DIRECT3D12" value="d3d12"/>
       <choice name="VULKAN" value="vulkan"/>

--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -13062,6 +13062,7 @@
     <feature submenu="EMULATION" name="SCRIBBLE HEAP" group="ADVANCED SETTINGS" value="scribble_heap" description="Scribble 0xCD into all allocated heap memory." preset="switchauto"/>
     <feature submenu="EMULATION" name="PROTECT ZERO" group="ADVANCED SETTINGS" value="protect_zero" description="Hack needed for some games." preset="switchauto"/>
     <feature submenu="EMULATION" name="ENABLE D3D DEBUG LAYER" group="ADVANCED SETTINGS" value="xenia_d3d12_debug" description="Hack needed for some games (Too Human)." preset="switchauto"/>
+    <feature submenu="EMULATION" name="BREAK ON UNIMPLEMENTED INSTRUCTIONS" group="ADVANCED SETTINGS" value="break_on_unimplemented_instructions" description="Break to the host debugger (or crash if no debugger attached) if an unimplemented PowerPC instruction is encountered." preset="switchauto"/>
     <feature submenu="DRIVERS" name="VIDEO" group="ADVANCED SETTINGS" value="gpu">
       <choice name="DIRECT3D12" value="d3d12"/>
       <choice name="VULKAN" value="vulkan"/>

--- a/emulatorLauncher/Generators/Xenia.Generator.cs
+++ b/emulatorLauncher/Generators/Xenia.Generator.cs
@@ -198,6 +198,12 @@ namespace EmulatorLauncher
                             ini.AppendValue("Video", "internal_display_resolution", "8");
                     }
 
+                    //CPU section
+                    if (SystemConfig.isOptSet("break_on_unimplemented_instructions") && SystemConfig.getOptBoolean("break_on_unimplemented_instructions"))
+                        ini.AppendValue("CPU", "break_on_unimplemented_instructions", "true");
+                    else if (Features.IsSupported("break_on_unimplemented_instructions"))
+                        ini.AppendValue("CPU", "break_on_unimplemented_instructions", "false");
+
                     //GPU section
                     string video_driver = "\"" + SystemConfig["gpu"] + "\"";
                     if (SystemConfig.isOptSet("gpu") && !string.IsNullOrEmpty(SystemConfig["gpu"]))


### PR DESCRIPTION
Adding the "break_on_unimplemented_instructions"="Break to the host debugger (or crash if no debugger attached) if an unimplemented PowerPC instruction is encountered Can be needed for some games