### PR TITLE
Adjustments to Supermodel iteration order for inputs

### DIFF
--- a/emulatorLauncher/Generators/Model3.Controllers.cs
+++ b/emulatorLauncher/Generators/Model3.Controllers.cs
@@ -122,14 +122,11 @@ namespace EmulatorLauncher
 
             SimpleLogger.Instance.Info("[INFO] setting " + tech + " inputdriver in SuperModel.");
 
-            // Not sure about the index used by supermodel but it seems to be dinput
-            if (tech != "sdl")
-            {
-                j1index = c1.DirectInput != null ? c1.DirectInput.DeviceIndex + 1 : c1.DeviceIndex + 1;
+            // Input indexes in supermodel seem to always be DirectInput + 1, regardless of actual input system used
+            j1index = c1.DirectInput != null ? c1.DirectInput.DeviceIndex + 1 : c1.DeviceIndex + 1;
 
-                if (c2 != null && c2.Config != null)
-                    j2index = c2.DirectInput != null ? c2.DirectInput.DeviceIndex + 1 : c2.DeviceIndex + 1;
-            }
+            if (c2 != null && c2.Config != null)
+                j2index = c2.DirectInput != null ? c2.DirectInput.DeviceIndex + 1 : c2.DeviceIndex + 1;
 
             SimpleLogger.Instance.Info("[INFO] setting index of joystick 1 to " + j1index.ToString());
             SimpleLogger.Instance.Info("[INFO] setting index of joystick 2 to " + j2index.ToString());
@@ -140,7 +137,10 @@ namespace EmulatorLauncher
 
             var guns = RawLightgun.GetRawLightguns();
 
-            bool multigun = SystemConfig.isOptSet("multigun") && SystemConfig.getOptBoolean("multigun");
+            // default to multigun if we have more than one usable gun.
+            bool multigun = gunCount > 1 && guns.Length > 1;
+            if (SystemConfig.isOptSet("multigun"))
+                multigun = SystemConfig.getOptBoolean("multigun");
             if (multigun)
                 SimpleLogger.Instance.Info("[GUNS] Using multigun.");
 

--- a/emulatorLauncher/Generators/Model3.Controllers.cs
+++ b/emulatorLauncher/Generators/Model3.Controllers.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.IO;
 using EmulatorLauncher.Common;
@@ -149,9 +149,10 @@ namespace EmulatorLauncher
 
             if (gunCount > 0 && guns.Length > 0)
             {
-                mouseIndex1 = (guns[0].Index + 1).ToString();
+                // Adjust for Supermodel using a reverse iteration order: https://github.com/trzy/Supermodel/blob/master/Src/OSD/Windows/DirectInputSystem.cpp#L610
+                mouseIndex1 = (guns.Length - guns[0].Index).ToString();
                 if (gunCount > 1 && guns.Length > 1)
-                    mouseIndex2 = (guns[1].Index + 1).ToString();
+                    mouseIndex2 = (guns.Length - guns[1].Index).ToString();
 
                 if (SystemConfig.isOptSet("use_guns") && guns.Any(g => g.Type == RawLighGunType.SindenLightgun))
                 {


### PR DESCRIPTION
- Reverses order of lightguns, since that's what Supermodel does.
- Always use the DirectInput device index, regardless of input drivers.