### PR TITLE
Update Model3 controller logic.

### DIFF
--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -13792,7 +13792,7 @@
     <feature submenu="EMULATION" name="POWERPC FREQUENCY" group="ADVANCED SETTINGS" value="m3_ppc_frequency" description="Sets the PowerPC frequency in MHz. The default is 50." preset="sliderauto" preset-parameters="20 200 5 Mhz"/>
     <feature submenu="EMULATION" name="DISABLE MULTITHREADING" group="ADVANCED SETTINGS" value="m3_thread" description="Useful for single-threaded processors." preset="switchauto"/>
     <feature submenu="USER INTERFACE" name="SHOW FPS" group="ADVANCED SETTINGS" value="m3_fps" preset="switchauto"/>
-    <feature submenu="DRIVERS" name="INPUT" group="ADVANCED SETTINGS" value="inputdriver" description="Force input driver.">
+    <feature submenu="DRIVERS" name="INPUT" group="ADVANCED SETTINGS" value="inputdriver" description="Force input driver. Defaults to 'sdl', or 'dinput' if multiguns is enabled.">
       <choice name="SDL" value="sdl"/>
       <choice name="XINPUT" value="xinput"/>
       <choice name="SDL (nintendo)" value="nintendo"/>
@@ -13836,7 +13836,7 @@
       <choice name="P2 only" value="2"/>
       <choice name="P1 &amp; P2" value="3"/>
     </feature>
-    <feature submenu="GUNS" name="MULTIGUN (RAW INPUT)" group="ADVANCED SETTINGS" value="multigun" description="When using multiple guns, set this on to switch driver to 'rawinput'." preset="switchauto"/>
+    <feature submenu="GUNS" name="MULTIGUN (RAW INPUT)" group="ADVANCED SETTINGS" value="multigun" description="When using multiple guns, set this on to set the input system to 'rawinput'. Setting this on changes the default input driver to 'dinput'. Defaults to on if multiple guns are found and input driver is not set to 'sdl'." preset="switchauto"/>
     <feature submenu="GUNS" name="GUN 1 INDEX" group="ADVANCED SETTINGS" value="supermodel_gun1">
       <choice name="1" value="1"/>
       <choice name="2" value="2"/>

--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -13792,7 +13792,7 @@
     <feature submenu="EMULATION" name="POWERPC FREQUENCY" group="ADVANCED SETTINGS" value="m3_ppc_frequency" description="Sets the PowerPC frequency in MHz. The default is 50." preset="sliderauto" preset-parameters="20 200 5 Mhz"/>
     <feature submenu="EMULATION" name="DISABLE MULTITHREADING" group="ADVANCED SETTINGS" value="m3_thread" description="Useful for single-threaded processors." preset="switchauto"/>
     <feature submenu="USER INTERFACE" name="SHOW FPS" group="ADVANCED SETTINGS" value="m3_fps" preset="switchauto"/>
-    <feature submenu="DRIVERS" name="INPUT" group="ADVANCED SETTINGS" value="inputdriver" description="Force input driver. Defaults to 'sdl', or 'dinput' if multiguns is enabled.">
+    <feature submenu="DRIVERS" name="INPUT" group="ADVANCED SETTINGS" value="inputdriver" description="Force input driver. Defaults to 'sdl', 'dinput' if multiguns is enabled.">
       <choice name="SDL" value="sdl"/>
       <choice name="XINPUT" value="xinput"/>
       <choice name="SDL (nintendo)" value="nintendo"/>
@@ -13808,7 +13808,7 @@
       <choice name="7" value="7"/>
       <choice name="8" value="8"/>
     </feature>
-    <feature submenu="CONTROLS" name="FORCE PLAYER 2 PAD INDEX" group="ADVANCED SETTINGS" value="model3_p2index" description="Force P2 pad index, can be useful when using a controller on an arcade machine.">
+    <feature submenu="CONTROLS" name="FORCE PLAYER 2 PAD INDEX" group="ADVANCED SETTINGS" value="model3_p2index">
       <choice name="1" value="1"/>
       <choice name="2" value="2"/>
       <choice name="3" value="3"/>
@@ -13836,7 +13836,7 @@
       <choice name="P2 only" value="2"/>
       <choice name="P1 &amp; P2" value="3"/>
     </feature>
-    <feature submenu="GUNS" name="MULTIGUN (RAW INPUT)" group="ADVANCED SETTINGS" value="multigun" description="When using multiple guns, set this on to set the input system to 'rawinput'. Setting this on changes the default input driver to 'dinput'. Defaults to on if multiple guns are found and input driver is not set to 'sdl'." preset="switchauto"/>
+    <feature submenu="GUNS" name="MULTIGUN (RAW INPUT)" group="ADVANCED SETTINGS" value="multigun" description="Set this on when using multiple guns. Defaults to on if multiple guns are found and input driver is not set to 'sdl'." preset="switchauto"/>
     <feature submenu="GUNS" name="GUN 1 INDEX" group="ADVANCED SETTINGS" value="supermodel_gun1">
       <choice name="1" value="1"/>
       <choice name="2" value="2"/>

--- a/emulatorLauncher/Generators/Model3.Controllers.cs
+++ b/emulatorLauncher/Generators/Model3.Controllers.cs
@@ -330,8 +330,10 @@ namespace EmulatorLauncher
                 }
             }
 
-            SimpleLogger.Instance.Info("[INFO] setting index of joystick 1 to " + j1index.ToString() + " (" + c1.ToString()+")");
-            SimpleLogger.Instance.Info("[INFO] setting index of joystick 2 to " + j2index.ToString() + " (" + c2.ToString()+")");
+            if (c1 != null)
+                SimpleLogger.Instance.Info("[INFO] setting index of joystick 1 to " + j1index.ToString() + " (" + c1.ToString()+")");
+            if (c2 != null)
+                SimpleLogger.Instance.Info("[INFO] setting index of joystick 2 to " + j2index.ToString() + " (" + c2.ToString()+")");
 
             SimpleLogger.Instance.Info("[INFO] Writing controls to emulator .ini file.");
 


### PR DESCRIPTION
- Remove any per-rom InputSystem overrides.
- Fix SDL controller indexing.
- Update setting descriptions to match implementation.

I was caught off-guard by per-rom overrides to the `InputSystem` in `Supermodel.ini`, which took precedence over what was configured by the emulator launcher. I think it makes sense to let the launcher control the `InputSystem` entirely, so I added some code to ensure there are no overrides in place.

This uncovered an indexing issue with SDL -- which was expected, and now we're passing SDL controller indexes (+1) to Supermodel.

I also attempted to update the descriptions of the settings to match the current implementation. The choice to default to `dinput` when multiguns are auto-detected might be controversial. I had to pick between `dinput` and `xinput`, and the former should work with anything in `gamecontrollersdb.txt` while the latter requires the controller to have xinput layout, so I picked the former. If the opposite is preferred, or we want to have another setting like `multigun-default-input-driver: xinput/dinput/auto` (auto again.. 😅), lmk.

The wording is a little verbose, which would have been made simpler if we just defaulted multigun to false (with the UX implications that follow).