### PR TITLE
Add padtokeyboard features attribute to m2emulator in es_features.cfg

### DIFF
--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -11191,7 +11191,7 @@
     <sharedFeature submenu="USER INTERFACE" group="ADVANCED SETTINGS" value="discord"/>
   </emulator>
   <!-- MODEL2 -->
-  <emulator name="m2emulator">
+  <emulator name="m2emulator" features="padtokeyboard">
     <sharedFeature group="GENERAL SETTINGS" value="shaderset"/>
     <sharedFeature group="GENERAL SETTINGS" value="bezel"/>
     <sharedFeature submenu="TATTOO" group="GENERAL SETTINGS" value="tattoo"/>


### PR DESCRIPTION
Supporting padtokeyboard for model2 is very useful when using demulshooter in order to map controllers to keys like start/coin.

Tested and works with demulshooter locally.