### PR TITLE
Fix possible null reference exception in Model2.Controllers.cs when accessing key configuration if the controller has no such key

### DIFF
--- a/emulatorLauncher/Generators/Model2.Controllers.cs
+++ b/emulatorLauncher/Generators/Model2.Controllers.cs
@@ -1297,7 +1297,12 @@ namespace EmulatorLauncher
         {
             key = key.GetRevertedAxis(out bool revertAxis);
 
-            string esName = (c.Config[key].Name).ToString();
+            var keyConfig = c.Config[key];
+            if (keyConfig == null)
+            {
+                return 0x00;
+            }
+            string esName = keyConfig.Name.ToString();
 
             // Nintendo has no analog triggers : use right stick
             if (brand == "nintendo")


### PR DESCRIPTION
When mapping a controller for m2emulator, we need to handle case where the gamecontrollerdb entry has no entry for the key.