### PR TITLE
Added Steam/Windows ROM monitoring method

### DIFF
--- a/EmulatorLauncher.Common/User32.cs
+++ b/EmulatorLauncher.Common/User32.cs
@@ -145,6 +145,12 @@ namespace EmulatorLauncher.Common
         [DllImport("User32.dll", CharSet = CharSet.Auto)]
         public static extern int SetWindowPos(IntPtr hWnd, IntPtr hWndAfter, int X, int Y, int Width, int Height, [MarshalAs(UnmanagedType.U4)]SWP flags);
 
+        [DllImport("User32.dll", CharSet = CharSet.Auto)]
+        public static extern int GetSystemMetrics(int nIndex);
+
+        public const int SM_CXSCREEN = 0;
+        public const int SM_CYSCREEN = 1;
+
         [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool UpdateLayeredWindow(IntPtr hwnd, IntPtr hdcDst,

--- a/emulatorLauncher/Generators/SteamLauncher.Generator.cs
+++ b/emulatorLauncher/Generators/SteamLauncher.Generator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Microsoft.Win32;
 using System.IO;
 using System.Linq;
 using System.Diagnostics;
@@ -11,8 +12,12 @@ namespace EmulatorLauncher
     {
         class SteamGameLauncher : GameLauncher
         {
+            private Uri _uri;
+
             public SteamGameLauncher(Uri uri)
             {
+                _uri = uri;
+
                 // Call method to get Steam executable
                 string steamInternalDBPath = Path.Combine(Program.AppConfig.GetFullPath("retrobat"), "system", "tools", "steamexecutables.json");
                 LauncherExe = SteamLibrary.GetSteamGameExecutableName(uri, steamInternalDBPath);
@@ -22,32 +27,176 @@ namespace EmulatorLauncher
             {
                 // Check if steam is already running
                 bool uiExists = Process.GetProcessesByName("steam").Any();
-                SimpleLogger.Instance.Info("[INFO] Executable name : " + LauncherExe);
-                
+
+                if (string.IsNullOrEmpty(LauncherExe))
+                    SimpleLogger.Instance.Info("[INFO] Executable name not found for " + Path.GetFileNameWithoutExtension(path.FileName) + ". Using fallback detection methods.");
+                else
+                    SimpleLogger.Instance.Info("[INFO] Executable name : " + LauncherExe);
+
                 // Kill game if already running
                 KillExistingLauncherExes();
 
                 // Start game
                 Process.Start(path);
 
-                // Get running game process (30 seconds delay 30x1000)
-                var steamGame = GetLauncherExeProcess();
-
-                if (steamGame != null)
+                // If we have an executable name, we can monitor the process
+                if (!string.IsNullOrEmpty(LauncherExe))
                 {
-                    steamGame.WaitForExit();
-
-                    // Kill steam if it was not running previously or if option is set in RetroBat
-                    if (!uiExists || (Program.SystemConfig.isOptSet("killsteam") && Program.SystemConfig.getOptBoolean("killsteam")))
+                    var steamGame = GetLauncherExeProcess();
+                    if (steamGame != null)
                     {
-                        foreach (var ui in Process.GetProcessesByName("steam"))
+                        steamGame.WaitForExit();
+
+                        if (!uiExists || (Program.SystemConfig.isOptSet("killsteam") && Program.SystemConfig.getOptBoolean("killsteam")))
                         {
-                            try { ui.Kill(); }
-                            catch { }
+                            foreach (var ui in Process.GetProcessesByName("steam"))
+                            {
+                                try { ui.Kill(); }
+                                catch { }
+                            }
                         }
                     }
                 }
+                // Otherwise, use fallback methods
+                else
+                {
+                    // Fallback 1: Registry Monitoring
+                    bool registrySuccess = MonitorGameByRegistry();
+
+                    // Fallback 2: Window Focus Detection
+                    if (!registrySuccess)
+                    {
+                        SimpleLogger.Instance.Info("[INFO] Registry monitoring failed. Falling back to window focus detection.");
+                        var gameProcess = ExeLauncherGenerator.FindGameProcessByWindowFocus();
+                        if (gameProcess != null)
+                        {
+                            SimpleLogger.Instance.Info("[INFO] Game process '" + gameProcess.ProcessName + "' identified by window focus. Monitoring process.");
+                            gameProcess.WaitForExit();
+                            SimpleLogger.Instance.Info("[INFO] Game process has exited.");
+                        }
+                        else
+                        {
+                            SimpleLogger.Instance.Info("[INFO] All fallback methods failed. Unable to monitor game process.");
+                        }
+                    }
+                }
+
                 return 0;
+            }
+
+            private bool MonitorGameByRegistry()
+            {
+                string gameId = _uri.AbsolutePath.Substring(1);
+                int endurl = gameId.IndexOf("%");
+                if (endurl == -1)
+                    endurl = gameId.Length;
+                gameId = gameId.Substring(0, endurl);
+
+                int gameID = gameId.ToInteger();
+                if (gameID <= 0)
+                    return false;
+
+                SimpleLogger.Instance.Info("[INFO] Monitoring registry for game start (AppID: " + gameID + ").");
+
+                // Wait for the game to be marked as running, with a 60-second timeout
+                bool gameStarted = false;
+                for (int i = 0; i < 60; i++)
+                {
+                    try
+                    {
+                        using (var key = Registry.CurrentUser.OpenSubKey("SOFTWARE\\Valve\\Steam\\Apps\\" + gameID))
+                        {
+                            if (key != null && key.GetValue("Running") != null && (int)key.GetValue("Running") == 1)
+                            {
+                                gameStarted = true;
+                                break;
+                            }
+                        }
+                    }
+                    catch { }
+                    System.Threading.Thread.Sleep(1000);
+                }
+
+                if (!gameStarted)
+                {
+                    SimpleLogger.Instance.Info("[INFO] Timeout: Game did not appear as 'Running' in the registry.");
+                    return false;
+                }
+
+                SimpleLogger.Instance.Info("[INFO] Game detected as running. Monitoring registry for exit.");
+
+                // Wait for the game to exit
+                while (true)
+                {
+                    try
+                    {
+                        using (var key = Registry.CurrentUser.OpenSubKey("SOFTWARE\\Valve\\Steam\\Apps\\" + gameID))
+                        {
+                            if (key == null || (key.GetValue("Running") != null && (int)key.GetValue("Running") == 0))
+                                break;
+                        }
+                    }
+                    catch { }
+                    System.Threading.Thread.Sleep(1000);
+                }
+
+                SimpleLogger.Instance.Info("[INFO] Game has exited.");
+                return true;
+            }
+
+            private Process FindGameProcessByWindowFocus()
+            {
+                SimpleLogger.Instance.Info("[INFO] Trying to find game process by window focus.");
+
+                // Wait for initial window to appear (e.g., a launcher)
+                System.Threading.Thread.Sleep(10000); // 10 seconds
+
+                IntPtr hWnd = User32.GetForegroundWindow();
+                if (hWnd == IntPtr.Zero) return null;
+
+                uint pid;
+                User32.GetWindowThreadProcessId(hWnd, out pid);
+                if (pid == 0) return null;
+
+                Process candidateProcess = null;
+                try { candidateProcess = Process.GetProcessById((int)pid); }
+                catch { return null; }
+
+                SimpleLogger.Instance.Info("[INFO] Initial process candidate: " + candidateProcess.ProcessName);
+
+                // Wait longer for the actual game to take over from the launcher
+                System.Threading.Thread.Sleep(20000); // 20 more seconds
+
+                hWnd = User32.GetForegroundWindow();
+                if (hWnd == IntPtr.Zero) return null;
+
+                User32.GetWindowThreadProcessId(hWnd, out pid);
+                if (pid == 0) return null;
+
+                Process finalProcess = null;
+                try { finalProcess = Process.GetProcessById((int)pid); }
+                catch { return null; }
+
+                SimpleLogger.Instance.Info("[INFO] Final process candidate: " + finalProcess.ProcessName);
+
+                // Check if the final process is fullscreen
+                RECT windowRect;
+                User32.GetWindowRect(hWnd, out windowRect);
+
+                int screenWidth = User32.GetSystemMetrics(User32.SM_CXSCREEN);
+                int screenHeight = User32.GetSystemMetrics(User32.SM_CYSCREEN);
+
+                bool isFullscreen = (windowRect.left == 0 && windowRect.top == 0 &&
+                                     windowRect.right == screenWidth && windowRect.bottom == screenHeight);
+
+                if (isFullscreen)
+                {
+                    SimpleLogger.Instance.Info("[INFO] Final process '" + finalProcess.ProcessName + "' is fullscreen. Selecting it.");
+                    return finalProcess;
+                }
+                
+                SimpleLogger.Instance.Info("[INFO] Final process is not fullscreen. Detection by focus failed.");
+                return null;
             }
         }
     }


### PR DESCRIPTION
- Added a method to monitor Steam games using the "Running" value from the system registry.
- Added a fullscreen window focus method for Steam URLs, used as a fallback if previous methods fail — compatible with games added as non-Steam.
- Added the same fullscreen focus method for standalone Windows games: this allows handling pre-launcher executables from game-specific folders (e.g., .pc, .win). The system will wait for the final game to switch to fullscreen before starting monitoring on its executable.  


Priority for URL and LNK monitoring:
1 - Game exe (URL and LNK)
2 - Steamexecutables.json (Steam game URL)
3 - System registry (Steam game URL)
4 - Focus on fulscreen game (Steam game URL, not Steam game URL, LNK, Batch, CMD, folder.pc, etc.)

- (Steam) Removed search from appinfo.vdf.