### PR TITLE
tp-wheel / add GearUp/GearDown to Gear3/Gear4 converter for H-pattern shifters

### DIFF
--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -18441,7 +18441,11 @@
     <sharedFeature submenu="WHEELS" group="ADVANCED SETTINGS" value="gearstick_deviceid" order="602"/>
     <sharedFeature submenu="WHEELS" group="ADVANCED SETTINGS" value="wheel_coin_start" order="603"/>
     <sharedFeature submenu="WHEELS" group="ADVANCED SETTINGS" value="wheel_test_service" order="604"/>
-    <feature submenu="WHEELS" name="BATTLEGEAR4TUNED SHIFT MODE" group="ADVANCED SETTINGS" value="bg4t_shiftmode" description="Select shift mode for BattleGear4Tuned." order="605">
+    <feature submenu="WHEELS" name="GEARUP/GEARDOWN TO GEAR3/GEAR4 CONVERTER" group="ADVANCED SETTINGS" value="gearupdown_to_gear34" description="Convert gearup/geardown to gear3/gear4 for sequential shift simulation on standard gear stick." order="605">
+      <choice name="DISABLED" value="disabled"/>
+      <choice name="ENABLED" value="enabled"/>
+    </feature>
+    <feature submenu="WHEELS" name="BATTLEGEAR4TUNED SHIFT MODE" group="ADVANCED SETTINGS" value="bg4t_shiftmode" description="Select shift mode for BattleGear4Tuned." order="606">
       <choice name="SHIFT PADDLES" value="paddles"/>
       <choice name="SEQUENTIAL SHIFTERS" value="sequential"/>
       <choice name="PRO MODE SEQUENTIAL" value="prosequential"/>

--- a/emulatorLauncher/Generators/TeknoParrot.Wheels.cs
+++ b/emulatorLauncher/Generators/TeknoParrot.Wheels.cs
@@ -539,18 +539,101 @@ namespace EmulatorLauncher
                 }
             };
 
+            // Check if game has explicit mappings for gear slots to skip automatic defaults
+            // Also check for explicit null/disabled values
+            HashSet<string> disabledSlots = new HashSet<string>();
+            bool hasExplicitGear3 = gameSpecificKeys.Contains("Wmmt5GearChange3") || 
+                                   gameSpecificKeys.Contains("SrcGearChange3") ||
+                                   gameSpecificKeys.Contains("FnfGearChange3") ||
+                                   gameSpecificKeys.Contains("IDZGearChange3");
+            bool hasExplicitGear4 = gameSpecificKeys.Contains("Wmmt5GearChange4") || 
+                                   gameSpecificKeys.Contains("SrcGearChange4") ||
+                                   gameSpecificKeys.Contains("FnfGearChange4") ||
+                                   gameSpecificKeys.Contains("IDZGearChange4");
+            
+            // Check for explicit null/disabled values in game-specific mappings
+            if (gameButtonMappings.ContainsKey(tpGameName))
+            {
+                var gameMappings = gameButtonMappings[tpGameName];
+                foreach (var gm in gameMappings)
+                {
+                    string v = gm.Value != null ? gm.Value.Trim('"', '\'', ' ') : null;
+                    if (v != null && (v.Equals("null", StringComparison.OrdinalIgnoreCase) || 
+                                     v.Equals("disabled", StringComparison.OrdinalIgnoreCase) ||
+                                     v.Equals("none", StringComparison.OrdinalIgnoreCase)))
+                    {
+                        disabledSlots.Add(gm.Key);
+                    }
+                }
+            }
+
             // Pass 1: Apply generic defaults first (skip game-specific overridden keys)
             foreach (var btnEntry in buttonToInputMappings)
             {
                 if (!gameSpecificKeys.Contains(btnEntry.Key))
+                {
+                    // Skip any slots that are explicitly disabled in YAML
+                    bool skipMapping = false;
+                    foreach (var slot in btnEntry.Value)
+                    {
+                        string slotName = slot.ToString();
+                        if (disabledSlots.Contains(slotName))
+                        {
+                            skipMapping = true;
+                            break;
+                        }
+                    }
+                    if (skipMapping) continue;
+                    
+                    // Skip Gear3/Gear4 default mappings when converter is enabled OR when explicit YAML mappings exist
+                    if (gearConverterEnabled || hasExplicitGear3 || hasExplicitGear4)
+                    {
+                        bool skipGearMapping = false;
+                        foreach (var slot in btnEntry.Value)
+                        {
+                            if (slot == InputMapping.Wmmt5GearChange3 || slot == InputMapping.Wmmt5GearChange4 ||
+                                slot == InputMapping.SrcGearChange3 || slot == InputMapping.SrcGearChange4 ||
+                                slot == InputMapping.FnfGearChange3 || slot == InputMapping.FnfGearChange4 ||
+                                slot == InputMapping.IDZGearChange3 || slot == InputMapping.IDZGearChange4)
+                            {
+                                skipGearMapping = true;
+                                break;
+                            }
+                        }
+                        if (skipGearMapping) continue;
+                    }
                     mapButtonMulti(btnEntry.Key, btnEntry.Value);
+                }
             }
 
             // Pass 2: Apply game-specific overrides LAST so they always win over defaults
             foreach (var key in gameSpecificKeys)
             {
                 if (buttonToInputMappings.ContainsKey(key))
+                {
+                    // Skip any game-specific slots that are explicitly disabled in YAML
+                    if (disabledSlots.Contains(key))
+                        continue;
+                    
+                    // Skip Gear3/Gear4 game-specific mappings when converter is enabled
+                    if (gearConverterEnabled)
+                    {
+                        bool skipMapping = false;
+                        foreach (var slot in buttonToInputMappings[key])
+                        {
+                            if (slot == InputMapping.Wmmt5GearChange3 || slot == InputMapping.Wmmt5GearChange4 ||
+                                slot == InputMapping.SrcGearChange3 || slot == InputMapping.SrcGearChange4 ||
+                                slot == InputMapping.FnfGearChange3 || slot == InputMapping.FnfGearChange4 ||
+                                slot == InputMapping.IDZGearChange3 || slot == InputMapping.IDZGearChange4)
+                            {
+                                skipMapping = true;
+                                break;
+                            }
+                        }
+                        if (skipMapping) continue;
+                    }
                     mapButtonMulti(key, buttonToInputMappings[key]);
+                }
             }
 
             // Pass 3: Apply direct slot mappings from Syntax 1 (e.g. "P1Button1: boost", "Analog6: gas")

--- a/emulatorLauncher/Generators/TeknoParrot.Wheels.cs
+++ b/emulatorLauncher/Generators/TeknoParrot.Wheels.cs
@@ -405,6 +405,18 @@ namespace EmulatorLauncher
             var gameDirectSlotMappings = new Dictionary<InputMapping, string>();
 
             // Apply game-specific button mappings if available for this game
+            bool gearConverterEnabled = false;
+            bool noGearStick = Program.SystemConfig.getOptBoolean("wheel_nogearstick");
+            
+            // Only enable converter if there IS a gear stick (not nogearstick) and not for BattleGear4Tuned
+            if (!noGearStick && !tpGameName.StartsWith("battlegear4tuned"))
+            {
+                string gearConverter = Program.SystemConfig.isOptSet("gearupdown_to_gear34") ? Program.SystemConfig["gearupdown_to_gear34"] : "disabled";
+                gearConverterEnabled = (!string.IsNullOrEmpty(gearConverter) && gearConverter == "enabled");
+                if (gearConverterEnabled)
+                    SimpleLogger.Instance.Info("[WHEELS] GearUp/GearDown to Gear3/Gear4 converter enabled");
+            }
+
             if (gameButtonMappings.ContainsKey(tpGameName))
             {
                 var gameMappings = gameButtonMappings[tpGameName];
@@ -413,6 +425,18 @@ namespace EmulatorLauncher
                     string k = gm.Key;
                     string v = gm.Value != null ? gm.Value.Trim('"', '\'', ' ') : null;
                     if (string.IsNullOrEmpty(v)) continue;
+
+                    // Apply GearUp/GearDown to Gear3/Gear4 conversion if enabled
+                    if (gearConverterEnabled)
+                    {
+                        if (v.Equals("gearup", StringComparison.OrdinalIgnoreCase))
+                            v = "gear4";
+                        else if (v.Equals("geardown", StringComparison.OrdinalIgnoreCase))
+                            v = "gear3";
+                        // Skip original gear3/gear4 mappings when converter is enabled
+                        else if (v.Equals("gear3", StringComparison.OrdinalIgnoreCase) || v.Equals("gear4", StringComparison.OrdinalIgnoreCase))
+                            continue;
+                    }
 
                     // Syntax 1: InputMappingEnum: tag (e.g. P1ButtonStart: boost, Analog0: steer)
                     // Meaning: "apply the physical DInput code of the role 'tag' to this specific InputMapping slot"


### PR DESCRIPTION
- Add new option "GEARUP/GEARDOWN TO GEAR3/GEAR4 CONVERTER" in WHEELS settings
- Allows simulation of sequential shift on standard gear stick (ideal for 3D-printed sequential mods) by converting:
  - gearup → gear4 (Shift Up to Gear 4)
  - geardown → gear3 (Shift Down to Gear 3)
- Converter only applies when:
  - wheel_nogearstick is NOT enabled (requires gear stick)
  - Game is NOT a BattleGear4Tuned profile (already has specific modes)
- Original gear3/gear4 mappings are skipped when converter is enabled to avoid conflicts
- Some mappings in teknoparrot_wheel_mapping.yml

This feature enables users with standard H-pattern gear sticks to simulate sequential shifting behavior on games that only support gearup/geardown buttons.