### PR TITLE
Add a check of audio device availability

### DIFF
--- a/EmulatorLauncher.Common/AudioTools.cs
+++ b/EmulatorLauncher.Common/AudioTools.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace EmulatorLauncher.Common.Audio
+{
+    /// <summary>
+    /// Minimal MMDevice (WASAPI) interop : tells whether Windows currently exposes
+    /// a usable audio render endpoint, before starting an emulator.
+    /// </summary>
+    public static class AudioTools
+    {
+        private const int eRender = 0;
+        private const int eConsole = 0;
+        private const int DEVICE_STATE_ACTIVE = 0x00000001;
+
+        #region COM interop
+
+        [ComImport, Guid("BCDE0395-E52F-467C-8E3D-C4579291692E")]
+        private class MMDeviceEnumeratorComObject { }
+
+        [ComImport, Guid("A95664D2-9614-4F35-A746-DE8DB63617E6"),
+         InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        private interface IMMDeviceEnumerator
+        {
+            [PreserveSig] int EnumAudioEndpoints(int dataFlow, int stateMask, out IMMDeviceCollection devices);
+            [PreserveSig] int GetDefaultAudioEndpoint(int dataFlow, int role, out IMMDevice device);
+            [PreserveSig] int GetDevice([MarshalAs(UnmanagedType.LPWStr)] string id, out IMMDevice device);
+            [PreserveSig] int RegisterEndpointNotificationCallback(IntPtr client);
+            [PreserveSig] int UnregisterEndpointNotificationCallback(IntPtr client);
+        }
+
+        [ComImport, Guid("0BD7A1BE-7A1A-44DB-8397-CC5392387B5E"),
+         InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        private interface IMMDeviceCollection
+        {
+            [PreserveSig] int GetCount(out int count);
+            [PreserveSig] int Item(int index, out IMMDevice device);
+        }
+
+        [ComImport, Guid("D666063F-1587-4E43-81F1-B948E807363F"),
+         InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        private interface IMMDevice
+        {
+            [PreserveSig] int Activate(ref Guid iid, int clsCtx, IntPtr activationParams, out IntPtr iface);
+            [PreserveSig] int OpenPropertyStore(int stgmAccess, out IntPtr properties);
+            [PreserveSig] int GetId([MarshalAs(UnmanagedType.LPWStr)] out string id);
+            [PreserveSig] int GetState(out int state);
+        }
+
+        #endregion
+
+        /// <summary>
+        /// Number of render endpoints in DEVICE_STATE_ACTIVE.
+        /// Returns -1 when COM is unusable.
+        /// Used by LibRetro.Generator to decide whether pinning audio_device makes sense.
+        /// </summary>
+        public static int GetActiveRenderEndpointCount()
+        {
+            IMMDeviceEnumerator enumerator = null;
+            IMMDeviceCollection collection = null;
+
+            try
+            {
+                enumerator = (IMMDeviceEnumerator)new MMDeviceEnumeratorComObject();
+
+                if (enumerator.EnumAudioEndpoints(eRender, DEVICE_STATE_ACTIVE, out collection) != 0 || collection == null)
+                    return -1;
+
+                int count;
+                if (collection.GetCount(out count) != 0)
+                    return -1;
+
+                return count;
+            }
+            catch { return -1; }
+            finally
+            {
+                if (collection != null) Marshal.ReleaseComObject(collection);
+                if (enumerator != null) Marshal.ReleaseComObject(enumerator);
+            }
+        }
+
+        /// <summary>
+        /// Waits until Windows exposes at least one active render endpoint AND a default one.
+        /// Returns true when available, false on timeout. waitedMs reports the actual wait.
+        /// Never blocks when COM is unusable.
+        /// </summary>
+        public static bool WaitForRenderEndpoint(int timeoutMs, out int waitedMs)
+        {
+            const int pollMs = 200;
+
+            waitedMs = 0;
+            IMMDeviceEnumerator enumerator = null;
+
+            try
+            {
+                enumerator = (IMMDeviceEnumerator)new MMDeviceEnumeratorComObject();
+
+                while (true)
+                {
+                    IMMDeviceCollection collection = null;
+                    IMMDevice device = null;
+
+                    try
+                    {
+                        int count = 0;
+
+                        if (enumerator.EnumAudioEndpoints(eRender, DEVICE_STATE_ACTIVE, out collection) == 0
+                            && collection != null
+                            && collection.GetCount(out count) == 0
+                            && count > 0
+                            && enumerator.GetDefaultAudioEndpoint(eRender, eConsole, out device) == 0
+                            && device != null)
+                            return true;
+                    }
+                    finally
+                    {
+                        if (device != null) Marshal.ReleaseComObject(device);
+                        if (collection != null) Marshal.ReleaseComObject(collection);
+                    }
+
+                    if (waitedMs >= timeoutMs)
+                        return false;
+
+                    Thread.Sleep(pollMs);
+                    waitedMs += pollMs;
+                }
+            }
+            catch { return true; }   // COM unusable : never block startup
+            finally
+            {
+                if (enumerator != null) Marshal.ReleaseComObject(enumerator);
+            }
+        }
+    }
+}

--- a/EmulatorLauncher.Common/EmulatorLauncher.Common.csproj
+++ b/EmulatorLauncher.Common/EmulatorLauncher.Common.csproj
@@ -21,6 +21,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -60,6 +61,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="APIHook.cs" />
+    <Compile Include="AudioTools.cs" />
     <Compile Include="Compression\IArchive.cs" />
     <Compile Include="Compression\IArchiveEntry.cs" />
     <Compile Include="Compression\MountFile.cs" />

--- a/EmulatorLauncher.Common/ScreenResolution.cs
+++ b/EmulatorLauncher.Common/ScreenResolution.cs
@@ -97,6 +97,7 @@ namespace EmulatorLauncher.Common
 
         DEVMODE originalMode = new DEVMODE();
         bool changed = false;
+        public bool HasChanged { get { return changed; } }
 
         private ScreenResolution(int width, int height, int bitCount, int frequency, bool interlaced)
         {
@@ -115,8 +116,11 @@ namespace EmulatorLauncher.Common
         public void Apply()
         {
             var cur = CurrentResolution;
-            if (cur.Width == Width && cur.Height == Height && cur.BitsPerPel == BitsPerPel && cur.DisplayFrequency == DisplayFrequency)
+            if (cur.Width == Width && cur.Height == Height && cur.BitsPerPel == BitsPerPel && cur.DisplayFrequency == DisplayFrequency && cur.Interlaced == Interlaced)
+            {
+                SimpleLogger.Instance.Info("[ScreenResolution] Requested mode is already active (" + Width + "x" + Height + "x" + BitsPerPel + " " + DisplayFrequency + "Hz" + (Interlaced ? " Interlaced" : "") + ") - skipping display mode change.");
                 return;
+            }
 
             originalMode.dmSize = (short)Marshal.SizeOf(originalMode);
 

--- a/emulatorLauncher/Program.cs
+++ b/emulatorLauncher/Program.cs
@@ -768,6 +768,18 @@ namespace EmulatorLauncher
                         if (screenResolution != null && generator.DependsOnDesktopResolution)
                             screenResolution.Apply();
 
+                        // A change in display mode temporarily makes the HDMI audio endpoint (TV / amplifier) disappear.
+                        // On some configurations, the endpoint is simply not ready at launch. In both cases,
+                        // starting the emulator too early leaves it without sound.
+                        bool modeChanged = (screenResolution != null && screenResolution.HasChanged);
+                        int audioTimeout = modeChanged ? 5000 : 1500;
+                        int audioWaited;
+
+                        if (!EmulatorLauncher.Common.Audio.AudioTools.WaitForRenderEndpoint(audioTimeout, out audioWaited))
+                            SimpleLogger.Instance.Warning("[Audio] No active render endpoint" + (modeChanged ? " after display mode change" : "") + " - emulator may start without sound.");
+                        else if (audioWaited > 0)
+                            SimpleLogger.Instance.Info("[Audio] Render endpoint became available after " + audioWaited + "ms.");
+
                         if (!Program.SystemConfig.isOptSet("use_guns") || !Program.SystemConfig.getOptBoolean("use_guns"))
                             Cursor.Position = new System.Drawing.Point(Screen.PrimaryScreen.Bounds.Right, Screen.PrimaryScreen.Bounds.Bottom / 2);
 


### PR DESCRIPTION
This should fix case of loosing HDMI audio renderer in case of screen resolution change before running an emulator