### PR TITLE
winuae: pass win32.hardfile_path / win32.cd_path for .uae configs

### DIFF
--- a/emulatorLauncher/Generators/Uae.Generator.cs
+++ b/emulatorLauncher/Generators/Uae.Generator.cs
@@ -22,10 +22,14 @@ namespace EmulatorLauncher
 
             if (Path.GetExtension(rom).ToLower() == ".uae")
             {
+                string systemRomPath = Path.Combine(AppConfig.GetFullPath("roms"), system).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
                 return new ProcessStartInfo()
                 {
                     FileName = exe,
-                    Arguments = "\"" + rom + "\"",
+                    Arguments = "\"" + rom + "\""
+                              + " -s \"win32.hardfile_path=" + systemRomPath + "\""
+                              + " -s \"win32.cd_path=" + systemRomPath + "\"",
                     WorkingDirectory = path,
                 };
             }


### PR DESCRIPTION
Currently, .uae files can't use relative paths easily as they are related to winuae .exe directory, and looks like:
```
hardfile2=rw,DH0:"..\..\roms\amiga500\game.hdf",32,1,2,512,0,,uae0
```
They are not really portable between different systems, or cross compatible with batocera for example

This patch append roms\<system> to WinUAE's hardfile and CD search paths:
```
winuae64.exe "<rom>.uae" -s "win32.hardfile_path=<dir>" -s "win32.cd_path=<dir>"
```
allowing to have in the .uae file:
```
hardfile2=rw,DH0:"game.hdf",32,1,2,512,0,,uae0
```
(This is not breaking existing config if .uae file have the default hardfile_path=./, as it's appending another search path, not replacing the existing one)